### PR TITLE
Issue #23 bad ci output

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,10 +25,10 @@ jobs:
           deno-version: ${{ matrix.deno }}
 
       - name: Unit
-        run: deno test tests/unit
+        run: deno test --allow-env tests/unit
 
       - name: Integration
-        run: deno test --allow-run tests/integration
+        run: deno test --allow-run --allow-env tests/integration
 
   linter:
     strategy:

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (4ms)
 
 Rhum can also be used with [SuperDeno](https://github.com/asos-craigmorten/superdeno). You can also read [Craig Morten's](https://github.com/asos-craigmorten) tutorial on strengthening your testing process using both Rhum and SuperDeno, [here](https://dev.to/craigmorten/how-to-write-spec-tests-in-deno-55e8).
 
+Due to the trouble with modifying the output of tests, you will notice the output of your tests in your CI is different than what you see when running tests on your host machine. This is expected, as the CI does not like how we are changing the way Deno.test outputs results so to make the output readable, we have had to adopt a different format approach when tests are ran inside your CI.
+
 * Properties
     * [Rhum.asserts](#rhumasserts)
     * [Rhum.mocks](#rhummocks)

--- a/mod.ts
+++ b/mod.ts
@@ -315,11 +315,8 @@ export class RhumRunner {
     // Even if plans and/or suites are the same. I believe this the best
     // way we can display the output
     if (Deno.env.get("CI") === "true") {
-      console.log("is ci")
       newName = `${this.passed_in_test_plan} | ${this.passed_in_test_suite} | ${name}`;
       return newName
-    } else {
-      console.log("IS not ci")
     }
     if (this.test_plan_in_progress != this.passed_in_test_plan) {
       this.test_plan_in_progress = this.passed_in_test_plan;

--- a/mod.ts
+++ b/mod.ts
@@ -303,6 +303,24 @@ export class RhumRunner {
    */
   protected formatTestCaseName(name: string): string {
     let newName: string;
+    // (ebebbington) Unfortunately, due to the CI not correctly displaying output
+    // (it is  all over the place and just  completely unreadable as
+    // it doesn't play well with  our control characters), we need to
+    // display the test output differently, based on if the tests are
+    // being ran inside a CI or not. Nothing will change for the current
+    // way of doing things, but if the tests are being ran inside a CI,
+    // the format would be:
+    //    test <plan> | <suite> | <case> ... ok (2ms)
+    //    test <plan> | <suite> | <case> ... ok (2ms)
+    // Even if plans and/or suites are the same. I believe this the best
+    // way we can display the output
+    if (Deno.env.get("CI") === "true") {
+      console.log("is ci")
+      newName = `${this.passed_in_test_plan} | ${this.passed_in_test_suite} | ${name}`;
+      return newName
+    } else {
+      console.log("IS not ci")
+    }
     if (this.test_plan_in_progress != this.passed_in_test_plan) {
       this.test_plan_in_progress = this.passed_in_test_plan;
       this.test_suite_in_progress = this.passed_in_test_suite;

--- a/mod.ts
+++ b/mod.ts
@@ -315,8 +315,9 @@ export class RhumRunner {
     // Even if plans and/or suites are the same. I believe this the best
     // way we can display the output
     if (Deno.env.get("CI") === "true") {
-      newName = `${this.passed_in_test_plan} | ${this.passed_in_test_suite} | ${name}`;
-      return newName
+      newName =
+        `${this.passed_in_test_plan} | ${this.passed_in_test_suite} | ${name}`;
+      return newName;
     }
     if (this.test_plan_in_progress != this.passed_in_test_plan) {
       this.test_plan_in_progress = this.passed_in_test_plan;

--- a/src/test_case.ts
+++ b/src/test_case.ts
@@ -49,7 +49,9 @@ export class TestCase {
           }
         };
         await Deno.test(c.name, async () => {
-          Deno.stdout.writeSync(encoder.encode(c.new_name));
+          if (Deno.env.get("CI") !== "true") {
+            Deno.stdout.writeSync(encoder.encode(c.new_name));
+          }
           await hookAttachedTestFn();
         });
       });

--- a/src/test_case.ts
+++ b/src/test_case.ts
@@ -55,8 +55,8 @@ export class TestCase {
         // based on if the tests are being ran inside a CI job
         if (Deno.env.get("CI") === "true") {
           await Deno.test(c.new_name, async () => {
-            await hookAttachedTestFn()
-          })
+            await hookAttachedTestFn();
+          });
         } else {
           await Deno.test(c.name, async () => {
             Deno.stdout.writeSync(encoder.encode(c.new_name));

--- a/src/test_case.ts
+++ b/src/test_case.ts
@@ -48,6 +48,11 @@ export class TestCase {
             this.plan.after_all_suite_hook();
           }
         };
+        // (ebebbington) To stop the output of test running being horrible
+        // in the CI, we will only display the new name which should be
+        // "plan | suite " case", as opposed to the "super saiyan"
+        // version. This name is generated differently inside `formatTestCaseName`
+        // based on if the tests are being ran inside a CI job
         if (Deno.env.get("CI") === "true") {
           await Deno.test(c.new_name, async () => {
             await hookAttachedTestFn()

--- a/src/test_case.ts
+++ b/src/test_case.ts
@@ -48,12 +48,16 @@ export class TestCase {
             this.plan.after_all_suite_hook();
           }
         };
-        await Deno.test(c.name, async () => {
-          if (Deno.env.get("CI") !== "true") {
+        if (Deno.env.get("CI") === "true") {
+          await Deno.test(c.new_name, async () => {
+            await hookAttachedTestFn()
+          })
+        } else {
+          await Deno.test(c.name, async () => {
             Deno.stdout.writeSync(encoder.encode(c.new_name));
-          }
-          await hookAttachedTestFn();
-        });
+            await hookAttachedTestFn();
+          });
+        }
       });
     });
   }

--- a/tests/integration/basic_test.ts
+++ b/tests/integration/basic_test.ts
@@ -10,7 +10,13 @@ Deno.test({
     "Integration | basic_test.ts | Tests correctly pass and display the correct output",
   async fn(): Promise<void> {
     const p = await Deno.run({
-      cmd: ["deno", "test", "--allow-run", "--allow-env", "example_tests/basic/tests_pass.ts"],
+      cmd: [
+        "deno",
+        "test",
+        "--allow-run",
+        "--allow-env",
+        "example_tests/basic/tests_pass.ts",
+      ],
       stdout: "piped",
       stderr: "piped",
       env: { "NO_COLOR": "false" },
@@ -81,34 +87,33 @@ Deno.test({
       "test test_case_3c2 ...         test_case_3c2 ... ok \n" +
       "\n" +
       "test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out";
-    const expectedResultWhenRanInCI =
-        "running 22 tests\n" +
-        "test test_plan_1 | test_suite_1a | test_case_1a1 ... ok \n" +
-        "test test_plan_1 | test_suite_1a | test_case_1a2 ... ok \n" +
-        "test test_plan_1 | test_suite_1a | test_case_1a3 ... ok \n" +
-        "test test_plan_1 | test_suite_1b | test_case_1b1 ... ok \n" +
-        "test test_plan_1 | test_suite_1b | test_case_1b2 ... ok \n" +
-        "test test_plan_1 | test_suite_1b | test_case_1b3 ... ok \n" +
-        "test test_plan_2 | test_suite_2a | test_case_2a1 ... ok \n" +
-        "test test_plan_2 | test_suite_2a | test_case_2a2 ... ok \n" +
-        "test test_plan_2 | test_suite_2a | test_case_2a3 ... ok \n" +
-        "test test_plan_2 | test_suite_2b | test_case_2b1 ... ok \n" +
-        "test test_plan_2 | test_suite_2b | test_case_2b2 ... ok \n" +
-        "test test_plan_2 | test_suite_2c | test_case_2c1 ... ok \n" +
-        "test test_plan_2 | test_suite_2c | test_case_2c2 ... ok \n" +
-        "test test_plan_2 | test_suite_2c | test_case_2c3 ... ok \n" +
-        "test test_plan_2 | test_suite_2d | test_case_2d1 ... ok \n" +
-        "test test_plan_2 | test_suite_2d | test_case_2d2 ... ok \n" +
-        "test test_plan_3 | test_suite_3a | test_case_3a1 ... ok \n" +
-        "test test_plan_3 | test_suite_3a | test_case_3a2 ... ok \n" +
-        "test test_plan_3 | test_suite_3b | test_case_3b1 ... ok \n" +
-        "test test_plan_3 | test_suite_3b | test_case_3b2 ... ok \n" +
-        "test test_plan_3 | test_suite_3c | test_case_3c1 ... ok \n" +
-        "test test_plan_3 | test_suite_3c | test_case_3c2 ... ok \n" +
-        "\n" +
-        "test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out"
+    const expectedResultWhenRanInCI = "running 22 tests\n" +
+      "test test_plan_1 | test_suite_1a | test_case_1a1 ... ok \n" +
+      "test test_plan_1 | test_suite_1a | test_case_1a2 ... ok \n" +
+      "test test_plan_1 | test_suite_1a | test_case_1a3 ... ok \n" +
+      "test test_plan_1 | test_suite_1b | test_case_1b1 ... ok \n" +
+      "test test_plan_1 | test_suite_1b | test_case_1b2 ... ok \n" +
+      "test test_plan_1 | test_suite_1b | test_case_1b3 ... ok \n" +
+      "test test_plan_2 | test_suite_2a | test_case_2a1 ... ok \n" +
+      "test test_plan_2 | test_suite_2a | test_case_2a2 ... ok \n" +
+      "test test_plan_2 | test_suite_2a | test_case_2a3 ... ok \n" +
+      "test test_plan_2 | test_suite_2b | test_case_2b1 ... ok \n" +
+      "test test_plan_2 | test_suite_2b | test_case_2b2 ... ok \n" +
+      "test test_plan_2 | test_suite_2c | test_case_2c1 ... ok \n" +
+      "test test_plan_2 | test_suite_2c | test_case_2c2 ... ok \n" +
+      "test test_plan_2 | test_suite_2c | test_case_2c3 ... ok \n" +
+      "test test_plan_2 | test_suite_2d | test_case_2d1 ... ok \n" +
+      "test test_plan_2 | test_suite_2d | test_case_2d2 ... ok \n" +
+      "test test_plan_3 | test_suite_3a | test_case_3a1 ... ok \n" +
+      "test test_plan_3 | test_suite_3a | test_case_3a2 ... ok \n" +
+      "test test_plan_3 | test_suite_3b | test_case_3b1 ... ok \n" +
+      "test test_plan_3 | test_suite_3b | test_case_3b2 ... ok \n" +
+      "test test_plan_3 | test_suite_3c | test_case_3c1 ... ok \n" +
+      "test test_plan_3 | test_suite_3c | test_case_3c2 ... ok \n" +
+      "\n" +
+      "test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out";
     if (Deno.env.get("CI") === "true") {
-      asserts.assertEquals(stdout, expectedResultWhenRanInCI)
+      asserts.assertEquals(stdout, expectedResultWhenRanInCI);
     } else {
       asserts.assertEquals(stdout, expectedResultWhenRanOnHost);
     }
@@ -120,7 +125,13 @@ Deno.test({
     "Integration | basic_test.ts | Tests correctly fail and display the correct output",
   async fn(): Promise<void> {
     const p = await Deno.run({
-      cmd: ["deno", "test", "--allow-run", "--allow-env", "example_tests/basic/tests_fail.ts"],
+      cmd: [
+        "deno",
+        "test",
+        "--allow-run",
+        "--allow-env",
+        "example_tests/basic/tests_fail.ts",
+      ],
       stdout: "piped",
       stderr: "piped",
       env: { "NO_COLOR": "true" },
@@ -214,99 +225,108 @@ Deno.test({
       "        test_case_3c1 ... ok \n" +
       "test test_case_3c2 ...         test_case_3c2 ... ok \n" +
       "\n";
-    const expectedTestCaseResultWhenRanInCI =
-        "running 22 tests\n" +
-        "test test_plan_1 | test_suite_1a | test_case_1a1 ... FAILED \n" +
-        "test test_plan_1 | test_suite_1a | test_case_1a2 ... ok \n" +
-        "test test_plan_1 | test_suite_1a | test_case_1a3 ... ok \n" +
-        "test test_plan_1 | test_suite_1b | test_case_1b1 ... ok \n" +
-        "test test_plan_1 | test_suite_1b | test_case_1b2 ... ok \n" +
-        "test test_plan_1 | test_suite_1b | test_case_1b3 ... FAILED \n" +
-        "test test_plan_2 | test_suite_2a | test_case_2a1 ... ok \n" +
-        "test test_plan_2 | test_suite_2a | test_case_2a2 ... ok \n" +
-        "test test_plan_2 | test_suite_2a | test_case_2a3 ... ok \n" +
-        "test test_plan_2 | test_suite_2b | test_case_2b1 ... ok \n" +
-        "test test_plan_2 | test_suite_2b | test_case_2b2 ... ok \n" +
-        "test test_plan_2 | test_suite_2c | test_case_2c1 ... ok \n" +
-        "test test_plan_2 | test_suite_2c | test_case_2c2 ... ok \n" +
-        "test test_plan_2 | test_suite_2c | test_case_2c3 ... ok \n" +
-        "test test_plan_2 | test_suite_2d | test_case_2d1 ... ok \n" +
-        "test test_plan_2 | test_suite_2d | test_case_2d2 ... ok \n" +
-        "test test_plan_3 | test_suite_3a | test_case_3a1 ... ok \n" +
-        "test test_plan_3 | test_suite_3a | test_case_3a2 ... ok \n" +
-        "test test_plan_3 | test_suite_3b | test_case_3b1 ... ok \n" +
-        "test test_plan_3 | test_suite_3b | test_case_3b2 ... ok \n" +
-        "test test_plan_3 | test_suite_3c | test_case_3c1 ... ok \n" +
-        "test test_plan_3 | test_suite_3c | test_case_3c2 ... ok \n" +
-        "\n";
+    const expectedTestCaseResultWhenRanInCI = "running 22 tests\n" +
+      "test test_plan_1 | test_suite_1a | test_case_1a1 ... FAILED \n" +
+      "test test_plan_1 | test_suite_1a | test_case_1a2 ... ok \n" +
+      "test test_plan_1 | test_suite_1a | test_case_1a3 ... ok \n" +
+      "test test_plan_1 | test_suite_1b | test_case_1b1 ... ok \n" +
+      "test test_plan_1 | test_suite_1b | test_case_1b2 ... ok \n" +
+      "test test_plan_1 | test_suite_1b | test_case_1b3 ... FAILED \n" +
+      "test test_plan_2 | test_suite_2a | test_case_2a1 ... ok \n" +
+      "test test_plan_2 | test_suite_2a | test_case_2a2 ... ok \n" +
+      "test test_plan_2 | test_suite_2a | test_case_2a3 ... ok \n" +
+      "test test_plan_2 | test_suite_2b | test_case_2b1 ... ok \n" +
+      "test test_plan_2 | test_suite_2b | test_case_2b2 ... ok \n" +
+      "test test_plan_2 | test_suite_2c | test_case_2c1 ... ok \n" +
+      "test test_plan_2 | test_suite_2c | test_case_2c2 ... ok \n" +
+      "test test_plan_2 | test_suite_2c | test_case_2c3 ... ok \n" +
+      "test test_plan_2 | test_suite_2d | test_case_2d1 ... ok \n" +
+      "test test_plan_2 | test_suite_2d | test_case_2d2 ... ok \n" +
+      "test test_plan_3 | test_suite_3a | test_case_3a1 ... ok \n" +
+      "test test_plan_3 | test_suite_3a | test_case_3a2 ... ok \n" +
+      "test test_plan_3 | test_suite_3b | test_case_3b1 ... ok \n" +
+      "test test_plan_3 | test_suite_3b | test_case_3b2 ... ok \n" +
+      "test test_plan_3 | test_suite_3c | test_case_3c1 ... ok \n" +
+      "test test_plan_3 | test_suite_3c | test_case_3c2 ... ok \n" +
+      "\n";
     if (Deno.env.get("CI") === "true") {
-      asserts.assertEquals(testCaseResults, expectedTestCaseResultWhenRanInCI)
-    } else {
-      asserts.assertEquals(testCaseResults, expectedTestCaseResultWhenRanOnHost);
-    }
-    const expectedFirstTestCaseFailureWhenRanOnHost  =
-        "\n" +
-        "\n" +
-        "test_case_1a1\n" +
-        "AssertionError: Values are not equal:\n" +
-        "\n" +
-        "\n" +
-        "    [Diff] Actual / Expected\n" +
-        "\n" +
-        "\n" +
-        "-   true\n" +
-        "+   false\n" +
-        "\n    ";
-    const expectedFirstTestCaseFailureWhenRanInCI =
-        "\n" +
-        "\n" +
-        "test_plan_1 | test_suite_1a | test_case_1a1\n" +
-        "AssertionError: Values are not equal:\n" +
-        "\n" +
-        "\n" +
-        "    [Diff] Actual / Expected\n" +
-        "\n" +
-        "\n" +
-        "-   true\n" +
-        "+   false\n" +
-        "\n    ";
-    if (Deno.env.get("CI") === "true") {
-      asserts.assertEquals(firstFailureResult, expectedFirstTestCaseFailureWhenRanInCI)
-    }  else {
-      asserts.assertEquals(firstFailureResult, expectedFirstTestCaseFailureWhenRanOnHost);
-    }
-    const expectedSecondTestCaseFailureWhenRanOnHost =
-        " ($deno$/testing.ts:358:20)\n" +
-        "\n" +
-        "test_case_1b3\n" +
-        "AssertionError: Values are not equal:\n" +
-        "\n" +
-        "\n" +
-        "    [Diff] Actual / Expected\n" +
-        "\n" +
-        "\n" +
-        "-   true\n" +
-        "+   false\n" +
-        "\n    "
-    const expectedSecondTestCaseFailureWhenRanInCI =
-        " ($deno$/testing.ts:358:20)\n" +
-        "\n" +
-        "test_plan_1 | test_suite_1b | test_case_1b3\n" +
-        "AssertionError: Values are not equal:\n" +
-        "\n" +
-        "\n" +
-        "    [Diff] Actual / Expected\n" +
-        "\n" +
-        "\n" +
-        "-   true\n" +
-        "+   false\n" +
-        "\n    ";
-    if (Deno.env.get("CI") === "true") {
-      asserts.assertEquals(secondFailureResult,  expectedSecondTestCaseFailureWhenRanInCI)
+      asserts.assertEquals(testCaseResults, expectedTestCaseResultWhenRanInCI);
     } else {
       asserts.assertEquals(
-          secondFailureResult,
-          expectedSecondTestCaseFailureWhenRanOnHost
+        testCaseResults,
+        expectedTestCaseResultWhenRanOnHost,
+      );
+    }
+    const expectedFirstTestCaseFailureWhenRanOnHost = "\n" +
+      "\n" +
+      "test_case_1a1\n" +
+      "AssertionError: Values are not equal:\n" +
+      "\n" +
+      "\n" +
+      "    [Diff] Actual / Expected\n" +
+      "\n" +
+      "\n" +
+      "-   true\n" +
+      "+   false\n" +
+      "\n    ";
+    const expectedFirstTestCaseFailureWhenRanInCI = "\n" +
+      "\n" +
+      "test_plan_1 | test_suite_1a | test_case_1a1\n" +
+      "AssertionError: Values are not equal:\n" +
+      "\n" +
+      "\n" +
+      "    [Diff] Actual / Expected\n" +
+      "\n" +
+      "\n" +
+      "-   true\n" +
+      "+   false\n" +
+      "\n    ";
+    if (Deno.env.get("CI") === "true") {
+      asserts.assertEquals(
+        firstFailureResult,
+        expectedFirstTestCaseFailureWhenRanInCI,
+      );
+    } else {
+      asserts.assertEquals(
+        firstFailureResult,
+        expectedFirstTestCaseFailureWhenRanOnHost,
+      );
+    }
+    const expectedSecondTestCaseFailureWhenRanOnHost =
+      " ($deno$/testing.ts:358:20)\n" +
+      "\n" +
+      "test_case_1b3\n" +
+      "AssertionError: Values are not equal:\n" +
+      "\n" +
+      "\n" +
+      "    [Diff] Actual / Expected\n" +
+      "\n" +
+      "\n" +
+      "-   true\n" +
+      "+   false\n" +
+      "\n    ";
+    const expectedSecondTestCaseFailureWhenRanInCI =
+      " ($deno$/testing.ts:358:20)\n" +
+      "\n" +
+      "test_plan_1 | test_suite_1b | test_case_1b3\n" +
+      "AssertionError: Values are not equal:\n" +
+      "\n" +
+      "\n" +
+      "    [Diff] Actual / Expected\n" +
+      "\n" +
+      "\n" +
+      "-   true\n" +
+      "+   false\n" +
+      "\n    ";
+    if (Deno.env.get("CI") === "true") {
+      asserts.assertEquals(
+        secondFailureResult,
+        expectedSecondTestCaseFailureWhenRanInCI,
+      );
+    } else {
+      asserts.assertEquals(
+        secondFailureResult,
+        expectedSecondTestCaseFailureWhenRanOnHost,
       );
     }
     asserts.assertEquals(

--- a/tests/integration/basic_test.ts
+++ b/tests/integration/basic_test.ts
@@ -10,7 +10,7 @@ Deno.test({
     "Integration | basic_test.ts | Tests correctly pass and display the correct output",
   async fn(): Promise<void> {
     const p = await Deno.run({
-      cmd: ["deno", "test", "--allow-run", "example_tests/basic/tests_pass.ts"],
+      cmd: ["deno", "test", "--allow-run", "--allow-env", "example_tests/basic/tests_pass.ts"],
       stdout: "piped",
       stderr: "piped",
       env: { "NO_COLOR": "false" },
@@ -90,7 +90,7 @@ Deno.test({
     "Integration | basic_test.ts | Tests correctly fail and display the correct output",
   async fn(): Promise<void> {
     const p = await Deno.run({
-      cmd: ["deno", "test", "--allow-run", "example_tests/basic/tests_fail.ts"],
+      cmd: ["deno", "test", "--allow-run", "--allow-env", "example_tests/basic/tests_fail.ts"],
       stdout: "piped",
       stderr: "piped",
       env: { "NO_COLOR": "true" },

--- a/tests/integration/basic_test.ts
+++ b/tests/integration/basic_test.ts
@@ -104,7 +104,7 @@ Deno.test({
         "test test_plan_3 | test_suite_3b | test_case_3b1 ... ok \n" +
         "test test_plan_3 | test_suite_3b | test_case_3b2 ... ok \n" +
         "test test_plan_3 | test_suite_3c | test_case_3c1 ... ok \n" +
-        "test test_plan_3 | test_suite_3c | test_case_3c2 ... ok\n" +
+        "test test_plan_3 | test_suite_3c | test_case_3c2 ... ok \n" +
         "\n" +
         "test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out"
     if (Deno.env.get("CI") === "true") {
@@ -237,7 +237,7 @@ Deno.test({
         "test test_plan_3 | test_suite_3b | test_case_3b1 ... ok \n" +
         "test test_plan_3 | test_suite_3b | test_case_3b2 ... ok \n" +
         "test test_plan_3 | test_suite_3c | test_case_3c1 ... ok \n" +
-        "test test_plan_3 | test_suite_3c | test_case_3c2 ... ok" +
+        "test test_plan_3 | test_suite_3c | test_case_3c2 ... ok \n" +
         "\n" +
         "test result: ok. 20 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out";
     if (Deno.env.get("CI") === "true") {

--- a/tests/integration/basic_test.ts
+++ b/tests/integration/basic_test.ts
@@ -256,11 +256,27 @@ Deno.test({
         "\n" +
         "-   true\n" +
         "+   false\n" +
-        "\n    "
-    asserts.assertEquals(firstFailureResult, expectedFirstTestCaseFailureWhenRanOnHost);
-    asserts.assertEquals(
-      secondFailureResult,
-      " ($deno$/testing.ts:358:20)\n" +
+        "\n    ";
+    const expectedFirstTestCaseFailureWhenRanInCI =
+        "\n" +
+        "\n" +
+        "test_plan_1 | test_suite_1a | test_case_1a1\n" +
+        "AssertionError: Values are not equal:\n" +
+        "\n" +
+        "\n" +
+        "    [Diff] Actual / Expected\n" +
+        "\n" +
+        "\n" +
+        "-   true\n" +
+        "+   false\n" +
+        "\n    ";
+    if (Deno.env.get("CI") === "true") {
+      asserts.assertEquals(firstFailureResult, expectedFirstTestCaseFailureWhenRanInCI)
+    }  else {
+      asserts.assertEquals(firstFailureResult, expectedFirstTestCaseFailureWhenRanOnHost);
+    }
+    const expectedSecondTestCaseFailureWhenRanOnHost =
+        " ($deno$/testing.ts:358:20)\n" +
         "\n" +
         "test_case_1b3\n" +
         "AssertionError: Values are not equal:\n" +
@@ -271,8 +287,28 @@ Deno.test({
         "\n" +
         "-   true\n" +
         "+   false\n" +
-        "\n    ",
-    );
+        "\n    "
+    const expectedSecondTestCaseFailureWhenRanInCI =
+        " ($deno$/testing.ts:358:20)\n" +
+        "\n" +
+        "test_plan_1 | test_suite_1b | test_case_1b3\n" +
+        "AssertionError: Values are not equal:\n" +
+        "\n" +
+        "\n" +
+        "    [Diff] Actual / Expected\n" +
+        "\n" +
+        "\n" +
+        "-   true\n" +
+        "+   false\n" +
+        "\n    ";
+    if (Deno.env.get("CI") === "true") {
+      asserts.assertEquals(secondFailureResult,  expectedSecondTestCaseFailureWhenRanInCI)
+    } else {
+      asserts.assertEquals(
+          secondFailureResult,
+          expectedSecondTestCaseFailureWhenRanOnHost
+      );
+    }
     asserts.assertEquals(
       stdout.indexOf(
         "test result: FAILED. 20 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out",

--- a/tests/integration/basic_test.ts
+++ b/tests/integration/basic_test.ts
@@ -82,6 +82,7 @@ Deno.test({
       "\n" +
       "test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out";
     const expectedResultWhenRanInCI =
+        "running 22 tests\n" +
         "test test_plan_1 | test_suite_1a | test_case_1a1 ... ok \n" +
         "test test_plan_1 | test_suite_1a | test_case_1a2 ... ok \n" +
         "test test_plan_1 | test_suite_1a | test_case_1a3 ... ok \n" +
@@ -212,6 +213,7 @@ Deno.test({
       "test test_case_3c2 ...         test_case_3c2 ... ok \n" +
       "\n";
     const expectedTestCaseResultWhenRanInCI =
+        "running 22 tests\n" +
         "test test_plan_1 | test_suite_1a | test_case_1a1 ... FAILED \n" +
         "test test_plan_1 | test_suite_1a | test_case_1a2 ... ok \n" +
         "test test_plan_1 | test_suite_1a | test_case_1a3 ... ok \n" +

--- a/tests/integration/basic_test.ts
+++ b/tests/integration/basic_test.ts
@@ -38,7 +38,7 @@ Deno.test({
      * There are also some odd empty lines at the end of the stdout... so we just strip those out
      */
     stdout = stdout.substring(0, stdout.indexOf("filtered out") + 12);
-    const expectedResult = "running 22 tests\n" +
+    const expectedResultWhenRanOnHost = "running 22 tests\n" +
       // Test plan 1
       "test test_case_1a1 ...                        \n" +
       "test_plan_1\n" +
@@ -81,7 +81,34 @@ Deno.test({
       "test test_case_3c2 ...         test_case_3c2 ... ok \n" +
       "\n" +
       "test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out";
-    asserts.assertEquals(stdout, expectedResult);
+    const expectedResultWhenRanInCI =
+        "test test_plan_1 | test_suite_1a | test_case_1a1 ... ok \n" +
+        "test test_plan_1 | test_suite_1a | test_case_1a2 ... ok \n" +
+        "test test_plan_1 | test_suite_1a | test_case_1a3 ... ok \n" +
+        "test test_plan_1 | test_suite_1b | test_case_1b1 ... ok \n" +
+        "test test_plan_1 | test_suite_1b | test_case_1b2 ... ok \n" +
+        "test test_plan_1 | test_suite_1b | test_case_1b3 ... ok \n" +
+        "test test_plan_2 | test_suite_2a | test_case_2a1 ... ok \n" +
+        "test test_plan_2 | test_suite_2a | test_case_2a2 ... ok \n" +
+        "test test_plan_2 | test_suite_2a | test_case_2a3 ... ok \n" +
+        "test test_plan_2 | test_suite_2b | test_case_2b1 ... ok \n" +
+        "test test_plan_2 | test_suite_2b | test_case_2b2 ... ok \n" +
+        "test test_plan_2 | test_suite_2c | test_case_2c1 ... ok \n" +
+        "test test_plan_2 | test_suite_2c | test_case_2c2 ... ok \n" +
+        "test test_plan_2 | test_suite_2c | test_case_2c3 ... ok \n" +
+        "test test_plan_2 | test_suite_2d | test_case_2d1 ... ok \n" +
+        "test test_plan_2 | test_suite_2d | test_case_2d2 ... ok \n" +
+        "test test_plan_3 | test_suite_3a | test_case_3a1 ... ok \n" +
+        "test test_plan_3 | test_suite_3a | test_case_3a2 ... ok \n" +
+        "test test_plan_3 | test_suite_3b | test_case_3b1 ... ok \n" +
+        "test test_plan_3 | test_suite_3b | test_case_3b2 ... ok \n" +
+        "test test_plan_3 | test_suite_3c | test_case_3c1 ... ok \n" +
+        "test test_plan_3 | test_suite_3c | test_case_3c2 ... ok";
+    if (Deno.env.get("CI") === "true") {
+      asserts.assertEquals(stdout, expectedResultWhenRanInCI)
+    } else {
+      asserts.assertEquals(stdout, expectedResultWhenRanOnHost);
+    }
   },
 });
 
@@ -142,7 +169,7 @@ Deno.test({
       splitStdout[1].split("at Object.runTests")[1].split(
         "at Module.assertEquals",
       )[0];
-    const expectedTestCaseResult = "running 22 tests\n" +
+    const expectedTestCaseResultWhenRanOnHost = "running 22 tests\n" +
       // Test plan 1
       "test test_case_1a1 ...                        \n" +
       "test_plan_1\n" +
@@ -184,10 +211,36 @@ Deno.test({
       "        test_case_3c1 ... ok \n" +
       "test test_case_3c2 ...         test_case_3c2 ... ok \n" +
       "\n";
-    asserts.assertEquals(testCaseResults, expectedTestCaseResult);
-    asserts.assertEquals(
-      firstFailureResult,
-      "\n" +
+    const expectedTestCaseResultWhenRanInCI =
+        "test test_plan_1 | test_suite_1a | test_case_1a1 ... FAILED \n" +
+        "test test_plan_1 | test_suite_1a | test_case_1a2 ... ok \n" +
+        "test test_plan_1 | test_suite_1a | test_case_1a3 ... ok \n" +
+        "test test_plan_1 | test_suite_1b | test_case_1b1 ... ok \n" +
+        "test test_plan_1 | test_suite_1b | test_case_1b2 ... ok \n" +
+        "test test_plan_1 | test_suite_1b | test_case_1b3 ... FAILED \n" +
+        "test test_plan_2 | test_suite_2a | test_case_2a1 ... ok \n" +
+        "test test_plan_2 | test_suite_2a | test_case_2a2 ... ok \n" +
+        "test test_plan_2 | test_suite_2a | test_case_2a3 ... ok \n" +
+        "test test_plan_2 | test_suite_2b | test_case_2b1 ... ok \n" +
+        "test test_plan_2 | test_suite_2b | test_case_2b2 ... ok \n" +
+        "test test_plan_2 | test_suite_2c | test_case_2c1 ... ok \n" +
+        "test test_plan_2 | test_suite_2c | test_case_2c2 ... ok \n" +
+        "test test_plan_2 | test_suite_2c | test_case_2c3 ... ok \n" +
+        "test test_plan_2 | test_suite_2d | test_case_2d1 ... ok \n" +
+        "test test_plan_2 | test_suite_2d | test_case_2d2 ... ok \n" +
+        "test test_plan_3 | test_suite_3a | test_case_3a1 ... ok \n" +
+        "test test_plan_3 | test_suite_3a | test_case_3a2 ... ok \n" +
+        "test test_plan_3 | test_suite_3b | test_case_3b1 ... ok \n" +
+        "test test_plan_3 | test_suite_3b | test_case_3b2 ... ok \n" +
+        "test test_plan_3 | test_suite_3c | test_case_3c1 ... ok \n" +
+        "test test_plan_3 | test_suite_3c | test_case_3c2 ... ok";
+    if (Deno.env.get("CI") === "true") {
+      asserts.assertEquals(testCaseResults, expectedTestCaseResultWhenRanInCI)
+    } else {
+      asserts.assertEquals(testCaseResults, expectedTestCaseResultWhenRanOnHost);
+    }
+    const expectedFirstTestCaseFailureWhenRanOnHost  =
+        "\n" +
         "\n" +
         "test_case_1a1\n" +
         "AssertionError: Values are not equal:\n" +
@@ -198,8 +251,8 @@ Deno.test({
         "\n" +
         "-   true\n" +
         "+   false\n" +
-        "\n    ",
-    );
+        "\n    "
+    asserts.assertEquals(firstFailureResult, expectedFirstTestCaseFailureWhenRanOnHost);
     asserts.assertEquals(
       secondFailureResult,
       " ($deno$/testing.ts:358:20)\n" +

--- a/tests/integration/basic_test.ts
+++ b/tests/integration/basic_test.ts
@@ -238,8 +238,7 @@ Deno.test({
         "test test_plan_3 | test_suite_3b | test_case_3b2 ... ok \n" +
         "test test_plan_3 | test_suite_3c | test_case_3c1 ... ok \n" +
         "test test_plan_3 | test_suite_3c | test_case_3c2 ... ok \n" +
-        "\n" +
-        "test result: ok. 20 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out";
+        "\n";
     if (Deno.env.get("CI") === "true") {
       asserts.assertEquals(testCaseResults, expectedTestCaseResultWhenRanInCI)
     } else {

--- a/tests/integration/basic_test.ts
+++ b/tests/integration/basic_test.ts
@@ -104,7 +104,9 @@ Deno.test({
         "test test_plan_3 | test_suite_3b | test_case_3b1 ... ok \n" +
         "test test_plan_3 | test_suite_3b | test_case_3b2 ... ok \n" +
         "test test_plan_3 | test_suite_3c | test_case_3c1 ... ok \n" +
-        "test test_plan_3 | test_suite_3c | test_case_3c2 ... ok";
+        "test test_plan_3 | test_suite_3c | test_case_3c2 ... ok\n" +
+        "\n" +
+        "test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out"
     if (Deno.env.get("CI") === "true") {
       asserts.assertEquals(stdout, expectedResultWhenRanInCI)
     } else {
@@ -235,7 +237,9 @@ Deno.test({
         "test test_plan_3 | test_suite_3b | test_case_3b1 ... ok \n" +
         "test test_plan_3 | test_suite_3b | test_case_3b2 ... ok \n" +
         "test test_plan_3 | test_suite_3c | test_case_3c1 ... ok \n" +
-        "test test_plan_3 | test_suite_3c | test_case_3c2 ... ok";
+        "test test_plan_3 | test_suite_3c | test_case_3c2 ... ok" +
+        "\n" +
+        "test result: ok. 20 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out";
     if (Deno.env.get("CI") === "true") {
       asserts.assertEquals(testCaseResults, expectedTestCaseResultWhenRanInCI)
     } else {


### PR DESCRIPTION
Fixes #23 

**WIP**

**Description**

* Add check inside `formatNewName`, for if the tests are ran inside a CI, then format the names. a different way (the second best looking way)

* Added allow env flags as thats what this feature will need

**Other Notes**

