### PR TITLE
assert-issue

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import { asserts } from "./src/rhum_asserts.ts";
+import { Asserts, asserts} from "./src/rhum_asserts.ts";
 import { MockServerRequestFn } from "./src/mocks/server_request.ts";
 import { TestCase } from "./src/test_case.ts";
 import {
@@ -63,7 +63,7 @@ export class RhumRunner {
    *     Rhum.asserts.assertEquals(true, true); // pass
    *     Rhum.asserts.assertEquals(true, false); // fail
    */
-  public asserts: asserts;
+  public asserts: Asserts;
 
   public mocks: RhumMocks;
 

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import { Asserts, asserts} from "./src/rhum_asserts.ts";
+import { Asserts, asserts } from "./src/rhum_asserts.ts";
 import { MockServerRequestFn } from "./src/mocks/server_request.ts";
 import { TestCase } from "./src/test_case.ts";
 import {

--- a/src/rhum_asserts.ts
+++ b/src/rhum_asserts.ts
@@ -12,18 +12,18 @@ export type asserts = typeof StdAsserts & typeof RhumAsserts;
 
 */
 export interface Asserts {
-  equal: Function,
-  assert: Function,
-  assertEquals: Function,
-  assertNotEquals: Function,
-  assertStrictEquals: Function,
-  assertStringContains: Function,
-  assertMatch: Function,
-  assertArrayContains: Function,
-  assertThrows: Function,
-  assertThrowsAsync: Function,
-  unimplemented: Function,
-  unreachable: Function,
+  equal: Function;
+  assert: Function;
+  assertEquals: Function;
+  assertNotEquals: Function;
+  assertStrictEquals: Function;
+  assertStringContains: Function;
+  assertMatch: Function;
+  assertArrayContains: Function;
+  assertThrows: Function;
+  assertThrowsAsync: Function;
+  unimplemented: Function;
+  unreachable: Function;
 }
 export const asserts: Asserts = {
   equal: StdAsserts.equal,
@@ -37,6 +37,6 @@ export const asserts: Asserts = {
   assertThrows: StdAsserts.assertThrows,
   assertThrowsAsync: StdAsserts.assertThrowsAsync,
   unimplemented: StdAsserts.unimplemented,
-  unreachable: StdAsserts.unreachable
+  unreachable: StdAsserts.unreachable,
 };
 export type asserts = typeof StdAsserts;

--- a/src/rhum_asserts.ts
+++ b/src/rhum_asserts.ts
@@ -11,6 +11,32 @@ export const asserts = {...StdAsserts, ...RhumAsserts };
 export type asserts = typeof StdAsserts & typeof RhumAsserts;
 
 */
-
-export const asserts = { ...StdAsserts };
+export interface Asserts {
+  equal: Function,
+  assert: Function,
+  assertEquals: Function,
+  assertNotEquals: Function,
+  assertStrictEquals: Function,
+  assertStringContains: Function,
+  assertMatch: Function,
+  assertArrayContains: Function,
+  assertThrows: Function,
+  assertThrowsAsync: Function,
+  unimplemented: Function,
+  unreachable: Function,
+}
+export const asserts: Asserts = {
+  equal: StdAsserts.equal,
+  assert: StdAsserts.assert,
+  assertEquals: StdAsserts.assertEquals,
+  assertNotEquals: StdAsserts.assertNotEquals,
+  assertStrictEquals: StdAsserts.assertStrictEquals,
+  assertStringContains: StdAsserts.assertStringContains,
+  assertMatch: StdAsserts.assertMatch,
+  assertArrayContains: StdAsserts.assertArrayContains,
+  assertThrows: StdAsserts.assertThrows,
+  assertThrowsAsync: StdAsserts.assertThrowsAsync,
+  unimplemented: StdAsserts.unimplemented,
+  unreachable: StdAsserts.unreachable
+};
 export type asserts = typeof StdAsserts;

--- a/tests/unit/mod_test.ts
+++ b/tests/unit/mod_test.ts
@@ -57,7 +57,7 @@ Deno.test({
     }
     const copyTestFn = testFn;
     Rhum.testPlan("Testing testCase", copyTestFn);
-    asserts.assertEquals(functionWasCalled, true);
+    Rhum.asserts.assert(functionWasCalled);
   },
 });
 


### PR DESCRIPTION
**Description**

* With v1.2.0, using `Rhum.asserts.assert` throw compilation errors. This PR fixes that issue, by modifying the asserts object Rhum has
