### PR TITLE
feat: only and skip support

### DIFF
--- a/example_tests/only/only_case.ts
+++ b/example_tests/only/only_case.ts
@@ -1,0 +1,29 @@
+import { Rhum } from "../../mod.ts";
+
+Rhum.testPlan("test_plan_1", () => {
+  Rhum.testSuite("test_suite_1a", () => {
+    Rhum.testCase("test_case_1a1", () => {
+      Rhum.asserts.assertEquals(true, true);
+    });
+    Rhum.testCase("test_case_1a2", () => {
+      Rhum.asserts.assertEquals(true, true);
+    });
+    Rhum.testCase("test_case_1a3", () => {
+      Rhum.asserts.assertEquals(true, true);
+    });
+  });
+
+  Rhum.testSuite("test_suite_1b", () => {
+    Rhum.testCase("test_case_1b1", () => {
+      Rhum.asserts.assertEquals(true, true);
+    });
+    Rhum.only("test_case_1b2", () => {
+      Rhum.asserts.assertEquals(true, true);
+    });
+    Rhum.testCase("test_case_1b3", () => {
+      Rhum.asserts.assertEquals(true, true);
+    });
+  });
+});
+
+Rhum.run();

--- a/example_tests/only/only_suite.ts
+++ b/example_tests/only/only_suite.ts
@@ -1,0 +1,29 @@
+import { Rhum } from "../../mod.ts";
+
+Rhum.testPlan("test_plan_1", () => {
+  Rhum.testSuite("test_suite_1a", () => {
+    Rhum.testCase("test_case_1a1", () => {
+      Rhum.asserts.assertEquals(true, true);
+    });
+    Rhum.testCase("test_case_1a2", () => {
+      Rhum.asserts.assertEquals(true, true);
+    });
+    Rhum.testCase("test_case_1a3", () => {
+      Rhum.asserts.assertEquals(true, true);
+    });
+  });
+
+  Rhum.only("test_suite_1b", () => {
+    Rhum.testCase("test_case_1b1", () => {
+      Rhum.asserts.assertEquals(true, true);
+    });
+    Rhum.testCase("test_case_1b2", () => {
+      Rhum.asserts.assertEquals(true, true);
+    });
+    Rhum.testCase("test_case_1b3", () => {
+      Rhum.asserts.assertEquals(true, true);
+    });
+  });
+});
+
+Rhum.run();

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -72,6 +72,7 @@ export interface ITestPlan {
   suites: {
     [key: string]: ITestSuite; // "key" is the suite name
   };
+  only: boolean;
   after_all_suite_hook?: Function;
   after_each_suite_hook?: Function;
   before_all_suite_hook?: Function;
@@ -96,6 +97,7 @@ export interface ITestPlan {
  */
 export interface ITestSuite {
   cases?: ITestCase[];
+  only: boolean;
   after_all_case_hook?: Function;
   after_each_case_hook?: Function;
   before_all_case_hook?: Function;
@@ -118,6 +120,7 @@ export interface ITestSuite {
  */
 export interface ITestCase {
   name: string;
+  only: boolean;
   new_name: string;
   testFn: Function;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -73,6 +73,7 @@ export interface ITestPlan {
     [key: string]: ITestSuite; // "key" is the suite name
   };
   only: boolean;
+  skip: boolean;
   after_all_suite_hook?: () => void;
   after_each_suite_hook?: () => void;
   before_all_suite_hook?: () => void;
@@ -98,6 +99,7 @@ export interface ITestPlan {
 export interface ITestSuite {
   cases?: ITestCase[];
   only: boolean;
+  skip: boolean;
   after_all_case_hook?: () => void;
   after_each_case_hook?: () => void;
   before_all_case_hook?: () => void;
@@ -120,6 +122,7 @@ export interface ITestSuite {
  */
 export interface ITestCase {
   only: boolean;
+  skip: boolean;
   name: string;
   new_name: string;
   testFn: () => void;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -119,8 +119,8 @@ export interface ITestSuite {
  *     argument of Deno.test().
  */
 export interface ITestCase {
-  name: string;
   only: boolean;
+  name: string;
   new_name: string;
   testFn: () => void;
 }

--- a/src/test_case.ts
+++ b/src/test_case.ts
@@ -84,10 +84,12 @@ export class TestCase {
         }
         const numberOfExtraSpaces = longestCaseNameLen - c.name.length; // for example, it would be 0 for when it's the test with the longest case name. It's just the character difference between the current case name and longest, telling us how many spaces to add
 
-        const isOnly = this.plan.only || this.plan.suites[suiteName].only || c.only
+        const only = this.plan.only || this.plan.suites[suiteName].only || c.only
+        const skip = this.plan.skip || this.plan.suites[suiteName].skip || c.skip
+        const ignore = skip === true || only === true
         await Deno.test({
           name: c.new_name + " ".repeat(numberOfExtraSpaces),
-          ignore: isOnly === false,
+          ignore: ignore,
           async fn(): Promise<void> {
             await hookAttachedTestFn();
           }

--- a/src/test_case.ts
+++ b/src/test_case.ts
@@ -58,6 +58,7 @@ export class TestCase {
             await this.plan.after_all_suite_hook();
           }
         };
+
         // (ebebbington) To stop the output of test running being horrible
         // in the CI, we will only display the new name which should be
         // "plan | suite " case", as opposed to the "super saiyan"

--- a/tests/integration/only_test.ts
+++ b/tests/integration/only_test.ts
@@ -23,6 +23,7 @@ Deno.test({
     });
     const status = await p.status();
     p.close();
+    console.log(new TextDecoder().decode(await p.stderrOutput()))
     asserts.assertEquals(status.success, true);
     asserts.assertEquals(status.code, 0);
     /**

--- a/tests/integration/only_test.ts
+++ b/tests/integration/only_test.ts
@@ -1,0 +1,93 @@
+import { StdAsserts as asserts, colors } from "../../deps.ts";
+import {Rhum} from "../../mod.ts";
+
+/**
+ * To be clear, we are making sure that when a user runs their tests using Bourbon, that everything works correctly,
+ * and the output is correct
+ */
+
+Deno.test({
+  name: "Integration | only_test.ts | Only runs the test case that has `Rhum.only`",
+  async fn(): Promise<void> {
+    const p = await Deno.run({
+      cmd: [
+        "deno",
+        "test",
+        "--allow-run",
+        "--allow-env",
+        "example_tests/only/only_case.ts",
+      ],
+      stdout: "piped",
+      stderr: "piped",
+      env: {"NO_COLOR": "false"},
+    });
+    const status = await p.status();
+    p.close();
+    asserts.assertEquals(status.success, true);
+    asserts.assertEquals(status.code, 0);
+    /**
+     * Because the timing for each test is dynamic, we can't really test it ("... ok (3ms)"), so strip all that out
+     */
+    let stdout = new TextDecoder("utf-8")
+        .decode(await p.output())
+        .replace(/\(\d+ms\)/g, ""); // (*ms)
+    /**
+     * There are also some odd empty lines at the end of the stdout... so we just strip those out
+     */
+    stdout = stdout.substring(0, stdout.indexOf("filtered out") + 12);
+
+    Rhum.asserts.assertEquals(stdout,
+        "running 1 tests\n" +
+        "                       \n" +
+        "test_plan_1\n" +
+        "    test_suite_1b\n" +
+        "        test_case_1b2 ... ok \n" +
+        "\n" +
+        "test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out "
+    )
+  }
+})
+
+Deno.test({
+  name: "Integration | only_test.ts | Only runs the test suite that has `Rhum.only`",
+  async fn(): Promise<void> {
+    const p = await Deno.run({
+      cmd: [
+        "deno",
+        "test",
+        "--allow-run",
+        "--allow-env",
+        "example_tests/only/only_suite.ts",
+      ],
+      stdout: "piped",
+      stderr: "piped",
+      env: {"NO_COLOR": "false"},
+    });
+    const status = await p.status();
+    p.close();
+    asserts.assertEquals(status.success, true);
+    asserts.assertEquals(status.code, 0);
+    /**
+     * Because the timing for each test is dynamic, we can't really test it ("... ok (3ms)"), so strip all that out
+     */
+    let stdout = new TextDecoder("utf-8")
+        .decode(await p.output())
+        .replace(/\(\d+ms\)/g, ""); // (*ms)
+    /**
+     * There are also some odd empty lines at the end of the stdout... so we just strip those out
+     */
+    stdout = stdout.substring(0, stdout.indexOf("filtered out") + 12);
+
+    Rhum.asserts.assertEquals(stdout,
+        "running 1 tests\n" +
+        "                       \n" +
+        "test_plan_1\n" +
+        "    test_suite_1b\n" +
+        "        test_case_1b1 ... ok \n" +
+        "        test_case_1b2 ... ok \n" +
+        "        test_case_1b2 ... ok \n" +
+        "\n" +
+        "test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out "
+    )
+  }
+})


### PR DESCRIPTION
Fixes issue 5

**WIP**

**Developments so far**

* Implemented only usage
    * Only a single suite or case can be only'ed, if more than 1 is, theen rhum throws an error
    * Will show all other tests as ignored
* added skip support
    * same as above but as many test *'s can be skipped
* Temporarily changed the output of rhum, see below

**What's left**

* Complete and fix integration tests for only
* add unit and integration tests for skip
* add unit tests for only method
* correct the output format, and adjust tests for this

**Different types of output**

![image](https://user-images.githubusercontent.com/47337480/94084279-13440700-fdfd-11ea-92c4-e0ab97cdae59.png)

![image](https://user-images.githubusercontent.com/47337480/94084290-1939e800-fdfd-11ea-8dd0-f1b8eb55c485.png)
