### PR TITLE
[fix-type-errors] Fix compilation errors when using unstable

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -11,7 +11,7 @@ import type {
 } from "./src/types.ts";
 import { MockBuilder } from "./src/mock_builder.ts";
 
-export type { Constructor, Stubbed } from "./src/types.ts"
+export type { Constructor, Stubbed } from "./src/types.ts";
 export { MockBuilder } from "./src/mock_builder.ts";
 
 /**

--- a/mod.ts
+++ b/mod.ts
@@ -1,17 +1,17 @@
 import { asserts } from "./src/rhum_asserts.ts";
 import { MockServerRequestFn } from "./src/mocks/server_request.ts";
 import { TestCase } from "./src/test_case.ts";
-import {
+import type {
   ITestPlan,
   RhumMocks,
 } from "./src/interfaces.ts";
-import {
+import type {
   Constructor,
   Stubbed,
 } from "./src/types.ts";
 import { MockBuilder } from "./src/mock_builder.ts";
 
-export { Constructor, Stubbed } from "./src/types.ts";
+export type { Constructor, Stubbed } from "./src/types.ts"
 export { MockBuilder } from "./src/mock_builder.ts";
 
 /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { MockServerRequestFn } from "./mocks/server_request.ts";
+import type { MockServerRequestFn } from "./mocks/server_request.ts";
 
 /**
  * @remarks

--- a/src/mock_builder.ts
+++ b/src/mock_builder.ts
@@ -1,4 +1,4 @@
-import { Mocked, Constructor } from "./types.ts";
+import type { Mocked, Constructor } from "./types.ts";
 
 export class MockBuilder<T> {
   /**

--- a/src/test_case.ts
+++ b/src/test_case.ts
@@ -1,5 +1,5 @@
 const encoder = new TextEncoder();
-import { ITestPlan, ITestCase } from "./interfaces.ts";
+import type { ITestPlan, ITestCase } from "./interfaces.ts";
 
 /**
  * A class to help create uniform test case objects.


### PR DESCRIPTION
Issue came about from @divy on discord.

**Description**

* Compilation errors when using Rhum and unstable. This is because unstable is proper unstable... even when passing the `--unstable` flag to something that doesn't need it, it will throw the below errors:

![image](https://user-images.githubusercontent.com/47337480/93339407-73e2ab00-f823-11ea-97c2-852edf969f3e.png)
(Credit: @divy, discord)