### PR TITLE
fix: Add autocompletion to `Rhum.asserts`

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import { asserts } from "./src/rhum_asserts.ts";
+import { assertions, asserts } from "./src/rhum_asserts.ts";
 import { MockServerRequestFn } from "./src/mocks/server_request.ts";
 import { TestCase } from "./src/test_case.ts";
 import type {
@@ -64,7 +64,7 @@ export class RhumRunner {
    *     Rhum.asserts.assertEquals(true, false); // fail
    */
   // deno-lint-ignore ban-types Reason for this is, deno lint no longer allows `Function` and instead needs us to be explicit: `() => void`, but  because  we couldn't use that to  type the properties (we would just be copying Deno's interfaces word for word), we have to deal with `Function
-  public asserts = asserts;
+  public asserts: { [key in assertions]: Function } = asserts;
 
   public mocks: RhumMocks;
 

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import { asserts, assertions } from "./src/rhum_asserts.ts";
+import { asserts } from "./src/rhum_asserts.ts";
 import { MockServerRequestFn } from "./src/mocks/server_request.ts";
 import { TestCase } from "./src/test_case.ts";
 import type {
@@ -64,7 +64,7 @@ export class RhumRunner {
    *     Rhum.asserts.assertEquals(true, false); // fail
    */
   // deno-lint-ignore ban-types Reason for this is, deno lint no longer allows `Function` and instead needs us to be explicit: `() => void`, but  because  we couldn't use that to  type the properties (we would just be copying Deno's interfaces word for word), we have to deal with `Function
-  public asserts: { [key in assertions]: Function } = asserts;
+  public asserts = asserts;
 
   public mocks: RhumMocks;
 

--- a/mod.ts
+++ b/mod.ts
@@ -64,7 +64,7 @@ export class RhumRunner {
    *     Rhum.asserts.assertEquals(true, false); // fail
    */
   // deno-lint-ignore ban-types Reason for this is, deno lint no longer allows `Function` and instead needs us to be explicit: `() => void`, but  because  we couldn't use that to  type the properties (we would just be copying Deno's interfaces word for word), we have to deal with `Function
-  public asserts: {[key in assertions]: Function} = asserts;
+  public asserts: { [key in assertions]: Function } = asserts;
 
   public mocks: RhumMocks;
 

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import { asserts } from "./src/rhum_asserts.ts";
+import { asserts, assertions } from "./src/rhum_asserts.ts";
 import { MockServerRequestFn } from "./src/mocks/server_request.ts";
 import { TestCase } from "./src/test_case.ts";
 import type {
@@ -64,7 +64,7 @@ export class RhumRunner {
    *     Rhum.asserts.assertEquals(true, false); // fail
    */
   // deno-lint-ignore ban-types Reason for this is, deno lint no longer allows `Function` and instead needs us to be explicit: `() => void`, but  because  we couldn't use that to  type the properties (we would just be copying Deno's interfaces word for word), we have to deal with `Function
-  public asserts: { [key: string]: Function } = asserts;
+  public asserts: {[key in assertions]: Function} = asserts;
 
   public mocks: RhumMocks;
 

--- a/src/rhum_asserts.ts
+++ b/src/rhum_asserts.ts
@@ -1,5 +1,6 @@
 import { StdAsserts } from "../deps.ts";
 
-export const asserts = {
-  ...StdAsserts,
-};
+export const asserts = { ... StdAsserts }
+
+export type assertions = keyof typeof StdAsserts
+

--- a/src/rhum_asserts.ts
+++ b/src/rhum_asserts.ts
@@ -1,5 +1,22 @@
 import { StdAsserts } from "../deps.ts";
 
-export const asserts = { ...StdAsserts };
+export const asserts = {
+  AssertionError: StdAsserts.AssertionError,
+  _format: StdAsserts._format,
+  assert: StdAsserts.assert,
+  assertArrayContains: StdAsserts.assertArrayContains,
+  assertEquals: StdAsserts.assertEquals,
+  assertNotEquals: StdAsserts.assertNotEquals,
+  assertNotMatch: StdAsserts.assertNotMatch,
+  assertNotStrictEquals: StdAsserts.assertNotStrictEquals,
+  assertStrictEquals: StdAsserts.assertStrictEquals,
+  assertStringContains: StdAsserts.assertStringContains,
+  assertThrows: StdAsserts.assertThrows,
+  assertThrowsAsync: StdAsserts.assertThrowsAsync,
+  equal: StdAsserts.equal,
+  fail: StdAsserts.fail,
+  unimplemented: StdAsserts.unimplemented,
+  unreachable: StdAsserts.unreachable
+};
 
-export type assertions = keyof typeof StdAsserts;
+//export type assertions = keyof typeof StdAsserts;

--- a/src/rhum_asserts.ts
+++ b/src/rhum_asserts.ts
@@ -1,6 +1,5 @@
 import { StdAsserts } from "../deps.ts";
 
-export const asserts = { ... StdAsserts }
+export const asserts = { ...StdAsserts };
 
-export type assertions = keyof typeof StdAsserts
-
+export type assertions = keyof typeof StdAsserts;

--- a/src/rhum_asserts.ts
+++ b/src/rhum_asserts.ts
@@ -1,22 +1,26 @@
 import { StdAsserts } from "../deps.ts";
 
-export const asserts = {
-  AssertionError: StdAsserts.AssertionError,
-  _format: StdAsserts._format,
-  assert: StdAsserts.assert,
-  assertArrayContains: StdAsserts.assertArrayContains,
-  assertEquals: StdAsserts.assertEquals,
-  assertNotEquals: StdAsserts.assertNotEquals,
-  assertNotMatch: StdAsserts.assertNotMatch,
-  assertNotStrictEquals: StdAsserts.assertNotStrictEquals,
-  assertStrictEquals: StdAsserts.assertStrictEquals,
-  assertStringContains: StdAsserts.assertStringContains,
-  assertThrows: StdAsserts.assertThrows,
-  assertThrowsAsync: StdAsserts.assertThrowsAsync,
-  equal: StdAsserts.equal,
-  fail: StdAsserts.fail,
-  unimplemented: StdAsserts.unimplemented,
-  unreachable: StdAsserts.unreachable
-};
+// Saving this so i don't have to type it out for the 10th time
+// export const asserts = {
+//   AssertionError: StdAsserts.AssertionError,
+//   _format: StdAsserts._format,
+//   assert: StdAsserts.assert,
+//   assertArrayContains: StdAsserts.assertArrayContains,
+//   assertEquals: StdAsserts.assertEquals,
+//   assertNotEquals: StdAsserts.assertNotEquals,
+//   assertNotMatch: StdAsserts.assertNotMatch,
+//   assertNotStrictEquals: StdAsserts.assertNotStrictEquals,
+//   assertStrictEquals: StdAsserts.assertStrictEquals,
+//   assertStringContains: StdAsserts.assertStringContains,
+//   assertMatch: StdAsserts.assertMatch,
+//   assertThrows: StdAsserts.assertThrows,
+//   assertThrowsAsync: StdAsserts.assertThrowsAsync,
+//   equal: StdAsserts.equal,
+//   fail: StdAsserts.fail,
+//   unimplemented: StdAsserts.unimplemented,
+//   unreachable: StdAsserts.unreachable
+// };
 
-//export type assertions = keyof typeof StdAsserts;
+export const asserts = { ...StdAsserts };
+
+export type assertions = keyof typeof StdAsserts;


### PR DESCRIPTION
Fixes #63 

**Description**

* Issue was because when we did `asserts: {[key: string]: Function}`, it was just too dynamic and provided no intellisense

* With the help from #63, managed to create a type to assign to `asserts`
