### PR TITLE
Issue #28 and #21 mock method arguments

### DIFF
--- a/src/mock_builder.ts
+++ b/src/mock_builder.ts
@@ -75,8 +75,7 @@ export class MockBuilder<T> {
 
       if (nativeMethods.indexOf(method) == -1) {
 
-        // Define an object to track how many times this method was called and
-        // with what arguments it was last called with
+        // Define an object to track data for assertions
         if (!mock.methods[method]) {
           mock.methods[method] = {
             num_calls: 0,
@@ -102,7 +101,7 @@ export class MockBuilder<T> {
             ...params: unknown[]
           ) => unknown)(...args);
 
-          // Track what this method returned
+          // Track what this method last returned
           mock.methods[method].lastReturned = function (input: unknown) {
             return input == ret;
           }

--- a/src/mock_builder.ts
+++ b/src/mock_builder.ts
@@ -98,10 +98,16 @@ export class MockBuilder<T> {
             return i == a;
           }
 
-          return (original[method as keyof T] as unknown as (
+          const ret = (original[method as keyof T] as unknown as (
             ...params: unknown[]
-          ) => unknown)();
+          ) => unknown)(...args);
 
+          // Track what this method returned
+          mock.methods[method].lastReturned = function (input: unknown) {
+            return input == ret;
+          }
+
+          return ret;
         };
       } else {
         // copy nativeMethod directly without mocking

--- a/src/mock_builder.ts
+++ b/src/mock_builder.ts
@@ -46,7 +46,6 @@ export class MockBuilder<T> {
   public create(): Mocked<T> {
     // deno-lint-ignore no-explicit-any
     const mock: Mocked<any> = {
-      calls: {},
       methods: {},
       is_mock: true,
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export type Mocked<T> = T & {
   methods: {
     [k: string]: {
       num_calls: number;
+      lastReturned: (input: unknown) => boolean;
       wasLastCalledWith: (...input: unknown[]) => boolean;
       wasCalledTimes: (input: number) => boolean;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,13 @@ export type Constructor<T extends unknown> = new (...args: any[]) => T;
 
 export type Mocked<T> = T & {
   calls: { [k in keyof T]: T[k] extends () => void ? number : never };
+  methods: {
+    [k: string]: {
+      num_calls: number;
+      wasLastCalledWith: (...input: unknown[]) => boolean;
+      wasCalledTimes: (input: number) => boolean;
+    }
+  }
   is_mock: true;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,6 @@ export type TConstructorFunction<T> = {
 export type Constructor<T extends unknown> = new (...args: any[]) => T;
 
 export type Mocked<T> = T & {
-  calls: { [k in keyof T]: T[k] extends () => void ? number : never };
   methods: {
     [k: string]: {
       num_calls: number;

--- a/tests/integration/mock_test.ts
+++ b/tests/integration/mock_test.ts
@@ -63,7 +63,7 @@ Rhum.testPlan(() => {
       );
     });
 
-    Rhum.testCase("count() for outside function is tracked", () => {
+    Rhum.testCase("wasCalledTimes() tracks external function calls", () => {
       const mockMathService = Rhum
         .mock(MathService)
         .create();

--- a/tests/integration/mock_test.ts
+++ b/tests/integration/mock_test.ts
@@ -71,9 +71,23 @@ Rhum.testPlan(() => {
         .mock(TestObject)
         .withConstructorArgs("has mocked math service", mockMathService)
         .create();
-      Rhum.asserts.assertEquals(mockMathService.calls.add, 0);
+      Rhum.asserts.assert(mockMathService.methods.add.wasCalledTimes(0));
       mockTestObject.sum(1, 1);
-      Rhum.asserts.assertEquals(mockMathService.calls.add, 1);
+      Rhum.asserts.assert(mockMathService.methods.add.wasCalledTimes(1));
     });
+  });
+
+  Rhum.testCase("lastCalledWith() returns the expected args", () => {
+    const mockMathService = Rhum
+      .mock(MathService)
+      .create();
+    mockMathService.add(1, 1);
+    Rhum.asserts.assert(
+      mockMathService.methods.add.wasLastCalledWith([1, 1])
+    );
+    mockMathService.add(2, 1);
+    Rhum.asserts.assert(
+      mockMathService.methods.add.wasLastCalledWith([2, 1])
+    );
   });
 });

--- a/tests/integration/mock_test.ts
+++ b/tests/integration/mock_test.ts
@@ -75,33 +75,34 @@ Rhum.testPlan(() => {
       mockTestObject.sum(1, 1);
       Rhum.asserts.assert(mockMathService.methods.add.wasCalledTimes(1));
     });
-  });
 
-  Rhum.testCase("lastCalledWith() returns the expected args", () => {
-    const mockMathService = Rhum
-      .mock(MathService)
-      .create();
-    mockMathService.add(1, 1);
-    Rhum.asserts.assert(
-      mockMathService.methods.add.wasLastCalledWith([1, 1])
-    );
-    mockMathService.add(2, 1);
-    Rhum.asserts.assert(
-      mockMathService.methods.add.wasLastCalledWith([2, 1])
-    );
-  });
+    Rhum.testCase("lastCalledWith() returns the expected args", () => {
+      const mockMathService = Rhum
+        .mock(MathService)
+        .create();
+      mockMathService.add(1, 1);
+      Rhum.asserts.assert(
+        mockMathService.methods.add.wasLastCalledWith([1, 1])
+      );
+      mockMathService.add(2, 1);
+      Rhum.asserts.assert(
+        mockMathService.methods.add.wasLastCalledWith([2, 1])
+      );
+    });
 
-  Rhum.testCase("lastReturned() returns the expected return value", () => {
-    const mockMathService = Rhum
-      .mock(MathService)
-      .create();
-    mockMathService.add(1, 1);
-    Rhum.asserts.assert(
-      mockMathService.methods.add.lastReturned(2)
-    );
-    mockMathService.add(2, 1);
-    Rhum.asserts.assert(
-      mockMathService.methods.add.lastReturned(3)
-    );
+    Rhum.testCase("lastReturned() returns the expected return value", () => {
+      const mockMathService = Rhum
+        .mock(MathService)
+        .create();
+      mockMathService.add(1, 1);
+      Rhum.asserts.assert(
+        mockMathService.methods.add.lastReturned(2)
+      );
+      mockMathService.add(2, 1);
+      Rhum.asserts.assert(
+        mockMathService.methods.add.lastReturned(3)
+      );
+    });
+
   });
 });

--- a/tests/integration/mock_test.ts
+++ b/tests/integration/mock_test.ts
@@ -63,7 +63,7 @@ Rhum.testPlan(() => {
       );
     });
 
-    Rhum.testCase("call count for outside function is increased", () => {
+    Rhum.testCase("count() for outside function is tracked", () => {
       const mockMathService = Rhum
         .mock(MathService)
         .create();
@@ -88,6 +88,20 @@ Rhum.testPlan(() => {
     mockMathService.add(2, 1);
     Rhum.asserts.assert(
       mockMathService.methods.add.wasLastCalledWith([2, 1])
+    );
+  });
+
+  Rhum.testCase("lastReturned() returns the expected return value", () => {
+    const mockMathService = Rhum
+      .mock(MathService)
+      .create();
+    mockMathService.add(1, 1);
+    Rhum.asserts.assert(
+      mockMathService.methods.add.lastReturned(2)
+    );
+    mockMathService.add(2, 1);
+    Rhum.asserts.assert(
+      mockMathService.methods.add.lastReturned(3)
     );
   });
 });


### PR DESCRIPTION
Fixes #28 and #21.

**Description**

* adds `mock.methods.{someMethod}.wasLastCalledWith([arg1, arg2, etc.])`
* adds `mock.methods.{someMethod}.wasCalledTimes(numberOfTimes)`
* adds `mock.methods.{someMethod}.lastReturned(returnValue)`
* removes `mock.calls.{someMethod}`

See the [test file](https://github.com/drashland/rhum/pull/77/files#diff-4ee712bcf938161c96a3198cd7aa6fea52b411372ee626cd7c6c9ae62e720aa4) for examples of how they work.