### PR TITLE
feat: CLI --ignore option

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,25 +31,25 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: |
           export PATH="~/.deno/bin:$PATH"
-          rhum --ignore="tests/data/,tests/ignore" tests/unit
+          rhum test --ignore="tests/data/,tests/ignore" tests/unit
 
       - name: Run Integration Tests
         if: matrix.os != 'windows-latest'
         run: |
           export PATH="~/.deno/bin:$PATH"
-          rhum --ignore="tests/data/,tests/ignore" tests/integration
+          rhum test --ignore="tests/data/,tests/ignore" tests/integration
 
       - name: Run Unit Tests (windows)
         if: matrix.os == 'windows-latest'
         run: |
           $env:Path += ";C:\Users\runneradmin\.deno\bin"
-          rhum --ignore="tests/data/,tests/ignore" tests/unit
+          rhum test --ignore="tests/data/,tests/ignore" tests/unit
 
       - name: Run Integration Tests (windows)
         if: matrix.os == 'windows-latest'
         run: |
           $env:Path += ";C:\Users\runneradmin\.deno\bin"
-          rhum --ignore="tests/data/,tests/ignore" tests/integration
+          rhum test --ignore="tests/data/,tests/ignore" tests/integration
 
   linter:
     strategy:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,25 +31,25 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: |
           export PATH="~/.deno/bin:$PATH"
-          rhum tests/unit
+          rhum --ignore="tests/data/,tests/ignore" tests/unit
 
       - name: Run Integration Tests
         if: matrix.os != 'windows-latest'
         run: |
           export PATH="~/.deno/bin:$PATH"
-          rhum tests/integration
+          rhum --ignore="tests/data/,tests/ignore" tests/integration
 
       - name: Run Unit Tests (windows)
         if: matrix.os == 'windows-latest'
         run: |
           $env:Path += ";C:\Users\runneradmin\.deno\bin"
-          rhum tests/unit
+          rhum --ignore="tests/data/,tests/ignore" tests/unit
 
       - name: Run Integration Tests (windows)
         if: matrix.os == 'windows-latest'
         run: |
           $env:Path += ";C:\Users\runneradmin\.deno\bin"
-          rhum tests/integration
+          rhum --ignore="tests/data/,tests/ignore" tests/integration
 
   linter:
     strategy:

--- a/mod.ts
+++ b/mod.ts
@@ -323,16 +323,14 @@ export class RhumRunner {
    * Run the test plan.
    */
   public async runTestPlan(): Promise<void> {
-    const filters = Deno.args;
-    const filterTestCase = filters[0];
-    const filterTestSuite = filters[1];
+    const options = JSON.parse(Deno.args[0].slice());
 
-    if (filterTestCase != "undefined") {
-      return await this.runCaseFiltered(filterTestCase);
+    if (options.test_case) {
+      return await this.runCaseFiltered(options.test_case);
     }
 
-    if (filterTestSuite != "undefined") {
-      return await this.runSuiteFiltered(filterTestSuite);
+    if (options.test_suite) {
+      return await this.runSuiteFiltered(options.test_suite);
     }
 
     await this.runAllSuitesAndCases();
@@ -489,7 +487,7 @@ export class RhumRunner {
    *     });
    */
   public async testPlan(testSuites: () => void): Promise<void> {
-    this.test_plan.name = Deno.args[2];
+    this.test_plan.name = Deno.args[1];
     await testSuites();
     await this.runTestPlan();
   }

--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -1,20 +1,24 @@
 import { runTests } from "../../test_runner.ts";
-import { IFilters } from "../../interfaces.ts";
+import { IOptions } from "../../interfaces.ts";
 import { LoggerService } from "../../../deps.ts";
+import { getOptionValue } from "../../services/option_service.ts";
 
-const filters: IFilters = {};
+const options: IOptions = {};
 
 export async function test(args: string[]): Promise<void> {
   args.forEach((arg: string) => {
-    if (!filters.test_case) {
-      filters.test_case = getFilterTestCaseValue(arg);
+    if (!options.test_case) {
+      options.test_case = getOptionValue(arg, "--filter-test-case");
     }
-    if (!filters.test_suite) {
-      filters.test_suite = getFilterTestSuiteValue(arg);
+    if (!options.test_suite) {
+      options.test_suite = getOptionValue(arg, "--filter-test-suite");
+    }
+    if (!options.ignore) {
+      options.ignore = getOptionValue(arg, "--ignore");
     }
   });
 
-  if (filters.test_case && filters.test_suite) {
+  if (options.test_case && options.test_suite) {
     LoggerService.logError(
       "You cannot use --filter-test-case and --filter-test-suite together. Please specify one option.",
     );
@@ -28,22 +32,5 @@ export async function test(args: string[]): Promise<void> {
     Deno.exit(1);
   }
 
-  await runTests(testFileOrDir, filters);
-}
-
-function getFilterTestCaseValue(arg: string): string | null {
-  const match = arg.match(/--filter-test-case=.+/);
-  if (match) {
-    return match[0].split("=")[1];
-  }
-  return null;
-}
-
-function getFilterTestSuiteValue(arg: string): string | null {
-  const match = arg.match(/--filter-test-suite=.+/);
-  if (match) {
-    return match[0].split("=")[1];
-  }
-
-  return null;
+  await runTests(testFileOrDir, options);
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -56,7 +56,8 @@ export interface ITestPlanResults {
   errors: string;
 }
 
-export interface IFilters {
+export interface IOptions {
   test_case?: string | null;
   test_suite?: string | null;
+  ignore?: string | null;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -54,6 +54,7 @@ export interface ITestPlanResults {
   failed: number;
   skipped: number;
   errors: string;
+  ignored?: string[];
 }
 
 export interface IOptions {

--- a/src/services/option_service.ts
+++ b/src/services/option_service.ts
@@ -1,0 +1,17 @@
+/**
+ * Get an option value given an argument.
+ *
+ * @param argAndValue - The string containing both the arg and value. For
+ * example, --filter-test-case=hello
+ * @param arg - The arg alone. For example, --filter-test-case.
+ *
+ * @returns The value of the arg (if it exists);
+ */
+export function getOptionValue(argAndValue: string, arg: string): string | null {
+  const re = new RegExp(`${arg}.+`, "g");
+  const match = argAndValue.match(re);
+  if (match) {
+    return match[0].split("=")[1];
+  }
+  return null;
+}

--- a/src/services/option_service.ts
+++ b/src/services/option_service.ts
@@ -7,7 +7,10 @@
  *
  * @returns The value of the arg (if it exists);
  */
-export function getOptionValue(argAndValue: string, arg: string): string | null {
+export function getOptionValue(
+  argAndValue: string,
+  arg: string,
+): string | null {
   const re = new RegExp(`${arg}.+`, "g");
   const match = argAndValue.match(re);
   if (match) {

--- a/tests/integration/ignore/ignore_1/ignored_test.ts
+++ b/tests/integration/ignore/ignore_1/ignored_test.ts
@@ -1,0 +1,9 @@
+import { Rhum } from "../../../../mod.ts";
+
+Rhum.testPlan(() => {
+  Rhum.testSuite("testSuite: ignored", () => {
+    Rhum.testCase("testCase: ignored", () => {
+      Rhum.asserts.assertEquals(true, true);
+    });
+  });
+});

--- a/tests/integration/ignore/ignore_2/ignored_test.ts
+++ b/tests/integration/ignore/ignore_2/ignored_test.ts
@@ -1,0 +1,9 @@
+import { Rhum } from "../../../../mod.ts";
+
+Rhum.testPlan(() => {
+  Rhum.testSuite("testSuite: ignored", () => {
+    Rhum.testCase("testCase: ignored", () => {
+      Rhum.asserts.assertEquals(true, true);
+    });
+  });
+});

--- a/tests/integration/ignore_test.ts
+++ b/tests/integration/ignore_test.ts
@@ -1,0 +1,150 @@
+import { Rhum } from "../../mod.ts";
+import { colors } from "../../deps.ts";
+
+const decoder = new TextDecoder();
+
+Rhum.testPlan(() => {
+  Rhum.testSuite("ignore", () => {
+    Rhum.testCase("can ignore a test file", async () => {
+      const p = Deno.run({
+        cmd: [
+          "rhum",
+          "test",
+          `--ignore=ignored_test.ts`,
+          "tests/integration/ignore/ignore_1",
+        ],
+        stdout: "piped",
+      });
+      const stdout = decoder.decode(await p.output());
+      Rhum.asserts.assertEquals(
+        stdout,
+        data_ignoreFile,
+      );
+    });
+
+    Rhum.testCase("can ignore a multiple test files", async () => {
+      const p = Deno.run({
+        cmd: [
+          "rhum",
+          "test",
+          `--ignore=ignore_1/ignored_test.ts,ignore_2/ignored_test.ts`,
+          "tests/integration/ignore/",
+        ],
+        stdout: "piped",
+      });
+      const stdout = decoder.decode(await p.output());
+      Rhum.asserts.assertEquals(
+        stdout,
+        data_ignoreMultipleFiles,
+      );
+    });
+
+    Rhum.testCase("can ignore a directory", async () => {
+      const p = Deno.run({
+        cmd: [
+          "rhum",
+          "test",
+          `--ignore=ignore_1`,
+          "tests/integration/ignore/",
+        ],
+        stdout: "piped",
+      });
+      const stdout = decoder.decode(await p.output());
+      Rhum.asserts.assertEquals(
+        stdout,
+        data_ignoreDirectory,
+      );
+    });
+
+    Rhum.testCase("can ignore multiple directories", async () => {
+      const p = Deno.run({
+        cmd: [
+          "rhum",
+          "test",
+          `--ignore=ignore/ignore_1/,ignore/ignore_2`,
+          "tests/integration/ignore/",
+        ],
+        stdout: "piped",
+      });
+      const stdout = decoder.decode(await p.output());
+      Rhum.asserts.assertEquals(
+        stdout,
+        data_ignoreMultipleDirectories,
+      );
+    });
+  });
+});
+
+////////////////////////////////////////////////////////////////////////////////
+// DATA PROVIDERS //////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+const data_ignoreFile = `
+${colors.blue("INFO")} Starting Rhum
+${colors.blue("INFO")} Checking test file(s)
+${colors.blue("INFO")} Running test(s)
+
+
+
+Test Results: ${colors.green("0")} passed; ${colors.red("0")} failed; ${
+  colors.yellow("0")
+} skipped
+
+${colors.blue("INFO")} Ignored files and/or directories
+
+- ignored_test.ts
+`;
+
+const data_ignoreMultipleFiles = `
+${colors.blue("INFO")} Starting Rhum
+${colors.blue("INFO")} Checking test file(s)
+${colors.blue("INFO")} Running test(s)
+
+
+
+Test Results: ${colors.green("0")} passed; ${colors.red("0")} failed; ${
+  colors.yellow("0")
+} skipped
+
+${colors.blue("INFO")} Ignored files and/or directories
+
+- ignore_1/ignored_test.ts
+- ignore_2/ignored_test.ts
+`;
+
+const data_ignoreDirectory = `
+${colors.blue("INFO")} Starting Rhum
+${colors.blue("INFO")} Checking test file(s)
+${colors.blue("INFO")} Running test(s)
+
+
+tests/integration/ignore/ignore_2/ignored_test.ts
+    testSuite: ignored
+        ${colors.green("PASS")} testCase: ignored
+
+
+Test Results: ${colors.green("1")} passed; ${colors.red("0")} failed; ${
+  colors.yellow("0")
+} skipped
+
+${colors.blue("INFO")} Ignored files and/or directories
+
+- ignore_1
+`;
+
+const data_ignoreMultipleDirectories = `
+${colors.blue("INFO")} Starting Rhum
+${colors.blue("INFO")} Checking test file(s)
+${colors.blue("INFO")} Running test(s)
+
+
+
+Test Results: ${colors.green("0")} passed; ${colors.red("0")} failed; ${
+  colors.yellow("0")
+} skipped
+
+${colors.blue("INFO")} Ignored files and/or directories
+
+- ignore/ignore_1/
+- ignore/ignore_2
+`;


### PR DESCRIPTION
Implements #82

**Description**

* Adds `--ignore="directory|file|directories|files"` option to the `test` subcommand
* Ignored directories and files show up at the very end (see screenshot). Reason I didn't go with `x ignored` in the Test results line is because if a file was ignored, you'd still see the file name as the test plan. For example,

````
my_test_file_thats_ignored.  <------ ugly

my_test_file_not_ignored
    testSuite
        PASS testCase
````

![Screen Shot 2020-10-22 at 17 09 56](https://user-images.githubusercontent.com/12766301/96930262-6a370d80-1489-11eb-9996-68f7c196e09d.png)
