### PR TITLE
fix: still allow assert*Contains methods

### DIFF
--- a/src/rhum_asserts.ts
+++ b/src/rhum_asserts.ts
@@ -21,6 +21,10 @@ import { StdAsserts } from "../deps.ts";
 //   unreachable: StdAsserts.unreachable
 // };
 
-export const asserts = { ...StdAsserts };
+export const asserts = {
+  ...StdAsserts,
+  assertArrayContains: StdAsserts.assertArrayIncludes,
+  assertStringContains: StdAsserts.assertStringIncludes,
+};
 
-export type assertions = keyof typeof StdAsserts;
+export type assertions = keyof typeof asserts;

--- a/tests/integration/asserts_test.ts
+++ b/tests/integration/asserts_test.ts
@@ -18,14 +18,14 @@ Rhum.testPlan("asserts_test.ts", () => {
       const b = a;
       Rhum.asserts.assertStrictEquals(a, b);
     });
-    Rhum.testCase("assertStringIncludes", () => {
-      Rhum.asserts.assertStringIncludes("Test hello", "hello");
+    Rhum.testCase("assertStringContains", () => {
+      Rhum.asserts.assertStringContains("Test hello", "hello");
     });
     Rhum.testCase("assertMatch", () => {
       Rhum.asserts.assertMatch("Test hello", /hello/g);
     });
-    Rhum.testCase("assertArrayIncludes", () => {
-      Rhum.asserts.assertArrayIncludes(["t", "e", "s", "t"], ["t", "e"]);
+    Rhum.testCase("assertArrayContains", () => {
+      Rhum.asserts.assertArrayContains(["t", "e", "s", "t"], ["t", "e"]);
     });
     Rhum.testCase("assertThrows", () => {
       Rhum.asserts.assertThrows(() => {


### PR DESCRIPTION
There was a change to Deno's assert library where they changed the following:

```
assertArrayContains -> assertArrayIncludes
assertStringContains -> assertStringIncludes
```

To prevent breaking changes between Rhum users and Rhum, I'm making Rhum backwards compatible by mapping the old methods to the new methods.