### PR TITLE
fix: beforeAll() executing before each test case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 
 # directories
+tmp*/*
 tmp/*
 
 # exceptions

--- a/src/test_case.ts
+++ b/src/test_case.ts
@@ -25,37 +25,58 @@ export class TestCase {
     if (this.plan.hasOwnProperty("suites") === false) {
       return;
     }
+
+    // Track the execution of hooks
+    let executedBeforeAllSuiteHook = false;
+    let executedAfterAllSuiteHook = false;
+
     Object.keys(this.plan.suites).forEach((suiteName) => {
+
+      // Track the execution of hooks
+      let executedBeforeEachSuiteHook = false;
+      let executedAfterEachSuiteHook = false;
+      let executedBeforeAllCaseHook = false;
+      let executedAfterAllCaseHook = false;
+
       // Run cases
       this.plan!.suites[suiteName].cases!.forEach(async (c: ITestCase) => {
         // Run the case - required to run like this because the
         // hooks need to be ran inside the Deno.test call. Deno.test seems to queue
         // the tests, meaning all hooks are ran, and **then** the tests are ran
         const hookAttachedTestFn = async () => {
-          if (this.plan.before_all_suite_hook) {
+          if (this.plan.before_all_suite_hook && !executedBeforeAllSuiteHook) {
             await this.plan.before_all_suite_hook();
+            executedBeforeAllSuiteHook = true;
           }
-          if (this.plan.before_each_suite_hook) {
+          if (this.plan.before_each_suite_hook && !executedBeforeEachSuiteHook) {
             await this.plan.before_each_suite_hook();
+            executedBeforeEachSuiteHook = true;
           }
-          if (this.plan.suites[suiteName].before_all_case_hook) {
+          if (this.plan.suites[suiteName].before_all_case_hook && !executedBeforeAllCaseHook) {
             await this.plan.suites[suiteName].before_all_case_hook!();
+            executedBeforeAllCaseHook = true;
           }
           if (this.plan.suites[suiteName].before_each_case_hook) {
             await this.plan.suites[suiteName].before_each_case_hook!();
           }
+
           await c.testFn();
+
           if (this.plan.suites[suiteName].after_each_case_hook) {
             await this.plan.suites[suiteName].after_each_case_hook!();
           }
-          if (this.plan.suites[suiteName].after_all_case_hook) {
+          if (this.plan.suites[suiteName].after_all_case_hook &&
+              !executedAfterAllCaseHook) {
             await this.plan.suites[suiteName].after_all_case_hook!();
+            executedAfterAllCaseHook = true;
           }
-          if (this.plan.after_each_suite_hook) {
+          if (this.plan.after_each_suite_hook && !executedAfterEachSuiteHook) {
             await this.plan.after_each_suite_hook();
+            executedAfterEachSuiteHook = true;
           }
-          if (this.plan.after_all_suite_hook) {
+          if (this.plan.after_all_suite_hook && !executedAfterAllSuiteHook) {
             await this.plan.after_all_suite_hook();
+            executedAfterAllSuiteHook = true;
           }
         };
         // (ebebbington) To stop the output of test running being horrible

--- a/src/test_case.ts
+++ b/src/test_case.ts
@@ -31,7 +31,6 @@ export class TestCase {
     let executedAfterAllSuiteHook = false;
 
     Object.keys(this.plan.suites).forEach((suiteName) => {
-
       // Track the execution of hooks
       let executedBeforeEachSuiteHook = false;
       let executedAfterEachSuiteHook = false;
@@ -48,11 +47,16 @@ export class TestCase {
             await this.plan.before_all_suite_hook();
             executedBeforeAllSuiteHook = true;
           }
-          if (this.plan.before_each_suite_hook && !executedBeforeEachSuiteHook) {
+          if (
+            this.plan.before_each_suite_hook && !executedBeforeEachSuiteHook
+          ) {
             await this.plan.before_each_suite_hook();
             executedBeforeEachSuiteHook = true;
           }
-          if (this.plan.suites[suiteName].before_all_case_hook && !executedBeforeAllCaseHook) {
+          if (
+            this.plan.suites[suiteName].before_all_case_hook &&
+            !executedBeforeAllCaseHook
+          ) {
             await this.plan.suites[suiteName].before_all_case_hook!();
             executedBeforeAllCaseHook = true;
           }
@@ -65,8 +69,10 @@ export class TestCase {
           if (this.plan.suites[suiteName].after_each_case_hook) {
             await this.plan.suites[suiteName].after_each_case_hook!();
           }
-          if (this.plan.suites[suiteName].after_all_case_hook &&
-              !executedAfterAllCaseHook) {
+          if (
+            this.plan.suites[suiteName].after_all_case_hook &&
+            !executedAfterAllCaseHook
+          ) {
             await this.plan.suites[suiteName].after_all_case_hook!();
             executedAfterAllCaseHook = true;
           }

--- a/tests/integration/hooks/before_all_test.ts
+++ b/tests/integration/hooks/before_all_test.ts
@@ -11,11 +11,14 @@ Rhum.testPlan("before_all_test.ts", () => {
   Rhum.beforeAll(() => {
     suite_val = "Eric";
   });
+
   // Run the first test suite
   Rhum.testSuite("test suite 1", () => {
+
     Rhum.beforeAll(() => {
       case_val = 2;
     });
+
     Rhum.testCase("hooks properly set suite_val and case_val", () => {
       // Asserting the value has changed
       Rhum.asserts.assertEquals(suite_val, "Eric");
@@ -27,7 +30,8 @@ Rhum.testPlan("before_all_test.ts", () => {
     });
     Rhum.testCase("hooks properly set case_val", () => {
       // Assert the value has changed from 22 to 2 (after setting it to 22 in the above case)
-      Rhum.asserts.assertEquals(case_val, 2);
+      Rhum.asserts.assertEquals(case_val, 22);
+      Rhum.asserts.assertEquals(suite_val, "Ed");
     });
   });
 
@@ -38,11 +42,11 @@ Rhum.testPlan("before_all_test.ts", () => {
     });
     Rhum.testCase("hooks properly set suite_val and case_val", async () => {
       // Asserting the hook should have replaced the name
-      Rhum.asserts.assertEquals(suite_val, "Eric");
-      suite_val = "Ed";
+      Rhum.asserts.assertEquals(suite_val, "Ed");
       Rhum.asserts.assertEquals(case_val, 0);
     });
   });
+
   Rhum.testSuite("test suite 3", () => {
     let async_case_val = 5;
     Rhum.beforeAll(async () => {
@@ -51,6 +55,7 @@ Rhum.testPlan("before_all_test.ts", () => {
       });
     });
     Rhum.testCase("beforeAll hook can be async", () => {
+      Rhum.asserts.assertEquals(suite_val, "Ed");
       Rhum.asserts.assertEquals(async_case_val, 15);
     });
   });

--- a/tests/integration/hooks/before_all_test.ts
+++ b/tests/integration/hooks/before_all_test.ts
@@ -14,7 +14,6 @@ Rhum.testPlan("before_all_test.ts", () => {
 
   // Run the first test suite
   Rhum.testSuite("test suite 1", () => {
-
     Rhum.beforeAll(() => {
       case_val = 2;
     });

--- a/tests/integration/hooks/before_each_test.ts
+++ b/tests/integration/hooks/before_each_test.ts
@@ -8,20 +8,25 @@ let suite_val = "Ed";
 let case_val = 22;
 
 Rhum.testPlan("before_each_test.ts", () => {
+
   Rhum.beforeEach(() => {
+    console.log("eric");
     suite_val = "Eric";
   });
+
   // Run the first test suite
   Rhum.testSuite("test suite 1", () => {
+
     Rhum.beforeEach(() => {
       case_val = 2;
     });
+
     Rhum.testCase("suite_val is Eric", () => {
       Rhum.asserts.assertEquals(suite_val, "Eric");
       suite_val = "Ed";
     });
-    Rhum.testCase("suite_val is still Eric", () => {
-      Rhum.asserts.assertEquals(suite_val, "Eric");
+    Rhum.testCase("suite_val is Ed", () => {
+      Rhum.asserts.assertEquals(suite_val, "Ed");
     });
     Rhum.testCase("case_val is 2", () => {
       Rhum.asserts.assertEquals(case_val, 2);
@@ -34,27 +39,34 @@ Rhum.testPlan("before_each_test.ts", () => {
 
   // Run the second test suite
   Rhum.testSuite("test suite 2", () => {
+
     Rhum.beforeEach(() => {
       case_val = 0;
     });
+
     Rhum.testCase("suite_val is Eric", async () => {
       Rhum.asserts.assertEquals(suite_val, "Eric");
       suite_val = "Ed";
     });
-    Rhum.testCase("suite_val is still Eric", async () => {
-      Rhum.asserts.assertEquals(suite_val, "Eric");
+    Rhum.testCase("suite_val is Ed", async () => {
+      Rhum.asserts.assertEquals(suite_val, "Ed");
+      case_val = 1;
     });
     Rhum.testCase("case_val is 0", () => {
       Rhum.asserts.assertEquals(case_val, 0);
     });
   });
+
   Rhum.testSuite("test suite 3", () => {
+
     let async_case_val = 5;
+
     Rhum.beforeEach(async () => {
       await new Promise((resolve) => {
         setTimeout(() => resolve((async_case_val = 15)), 1000);
       });
     });
+
     Rhum.testCase("beforeEach hook can be async", () => {
       Rhum.asserts.assertEquals(async_case_val, 15);
     });

--- a/tests/integration/hooks/before_each_test.ts
+++ b/tests/integration/hooks/before_each_test.ts
@@ -10,7 +10,6 @@ let case_val = 22;
 Rhum.testPlan("before_each_test.ts", () => {
 
   Rhum.beforeEach(() => {
-    console.log("eric");
     suite_val = "Eric";
   });
 

--- a/tests/integration/hooks/before_each_test.ts
+++ b/tests/integration/hooks/before_each_test.ts
@@ -8,14 +8,12 @@ let suite_val = "Ed";
 let case_val = 22;
 
 Rhum.testPlan("before_each_test.ts", () => {
-
   Rhum.beforeEach(() => {
     suite_val = "Eric";
   });
 
   // Run the first test suite
   Rhum.testSuite("test suite 1", () => {
-
     Rhum.beforeEach(() => {
       case_val = 2;
     });
@@ -38,7 +36,6 @@ Rhum.testPlan("before_each_test.ts", () => {
 
   // Run the second test suite
   Rhum.testSuite("test suite 2", () => {
-
     Rhum.beforeEach(() => {
       case_val = 0;
     });
@@ -57,7 +54,6 @@ Rhum.testPlan("before_each_test.ts", () => {
   });
 
   Rhum.testSuite("test suite 3", () => {
-
     let async_case_val = 5;
 
     Rhum.beforeEach(async () => {


### PR DESCRIPTION
Closes #90 

## Summary

* Adds flags to check when hooks are executed and only executes them when they're set to false
* Fixes assertions in tests (we were doing it wrong). If you read the before_all and before_each tests in master, you'll see that they're incorrectly asserting values. That's why we didn't catch the issue mentioned in this PR.