### PR TITLE
fix: Mocking a class with getters doesn't set default initialised value

### DIFF
--- a/src/mock_builder.ts
+++ b/src/mock_builder.ts
@@ -58,15 +58,14 @@ export class MockBuilder<T> {
           this.constructor_fn.prototype,
           property,
         );
-      if (typeof desc!.get === 'function') { // handle getter/setters different so we can initise their default getter value
+      if (typeof desc!.get === "function") { // handle getter/setters different so we can initise their default getter value
         // deno-lint-ignore ban-ts-comment
         //@ts-ignore
-        mock[property] = original[property]
-       return; // continue
+        mock[property] = original[property];
+        return; // continue
       }
       mock[property] = desc!.value;
     });
-
 
     // Attach all of the original's functions to the mock
     this.getAllFunctions(original).forEach((method: string) => {

--- a/src/mock_builder.ts
+++ b/src/mock_builder.ts
@@ -61,7 +61,7 @@ export class MockBuilder<T> {
 
       // Handle getter/setters differently so we can initialise their default
       // getter value
-      if (typeof desc!.get === 'function') {
+      if (typeof desc!.get === "function") {
         // deno-lint-ignore ban-ts-comment
         //@ts-ignore
         mock[property] = original[property];

--- a/src/mock_builder.ts
+++ b/src/mock_builder.ts
@@ -58,12 +58,16 @@ export class MockBuilder<T> {
           this.constructor_fn.prototype,
           property,
         );
-      if (typeof desc!.get === "function") { // handle getter/setters different so we can initise their default getter value
+
+      // Handle getter/setters differently so we can initialise their default
+      // getter value
+      if (typeof desc!.get === 'function') {
         // deno-lint-ignore ban-ts-comment
         //@ts-ignore
         mock[property] = original[property];
         return; // continue
       }
+
       mock[property] = desc!.value;
     });
 

--- a/src/mock_builder.ts
+++ b/src/mock_builder.ts
@@ -58,8 +58,15 @@ export class MockBuilder<T> {
           this.constructor_fn.prototype,
           property,
         );
+      if (typeof desc!.get === 'function') { // handle getter/setters different so we can initise their default getter value
+        // deno-lint-ignore ban-ts-comment
+        //@ts-ignore
+        mock[property] = original[property]
+       return; // continue
+      }
       mock[property] = desc!.value;
     });
+
 
     // Attach all of the original's functions to the mock
     this.getAllFunctions(original).forEach((method: string) => {

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -1,0 +1,1 @@
+export { assertEquals } from "https://deno.land/std@0.134.0/testing/asserts.ts";

--- a/tests/integration/mock_test.ts
+++ b/tests/integration/mock_test.ts
@@ -1,4 +1,5 @@
 import { Rhum } from "../../mod.ts";
+import { assertEquals } from "../deps.ts";
 
 class MathService {
   public add(
@@ -173,7 +174,6 @@ Rhum.testPlan("mock_test.ts", () => {
       );
       Rhum.asserts.assertEquals(router.calls.handle, 3);
     });
-
     Rhum.testCase("Sets the default value for getters", () => {
       class Game {
       }

--- a/tests/integration/mock_test.ts
+++ b/tests/integration/mock_test.ts
@@ -174,6 +174,23 @@ Rhum.testPlan("mock_test.ts", () => {
       Rhum.asserts.assertEquals(router.calls.handle, 3);
     });
   });
+
+  await t.step("Sets the default value for getters", () => {
+    class Game {
+
+    }
+    class PlayersEngine {
+      private game = new Game
+      get Game() {
+        return this.game
+      }
+      set Game(val: Game) {
+        this.game = val
+      }
+    }
+    const mock = Mock(PlayersEngine).create();
+    assertEquals(mock.Game instanceof Game, true)
+  })
 });
 
 Rhum.run();

--- a/tests/integration/mock_test.ts
+++ b/tests/integration/mock_test.ts
@@ -176,20 +176,19 @@ Rhum.testPlan("mock_test.ts", () => {
 
     Rhum.testCase("Sets the default value for getters", () => {
       class Game {
-  
       }
       class PlayersEngine {
-        private game = new Game
+        private game = new Game();
         get Game() {
-          return this.game
+          return this.game;
         }
         set Game(val: Game) {
-          this.game = val
+          this.game = val;
         }
       }
       const mock = Rhum.mock(PlayersEngine).create();
-      Rhum.asserts.assertEquals(mock.Game instanceof Game, true)
-    })
+      Rhum.asserts.assertEquals(mock.Game instanceof Game, true);
+    });
   });
 });
 

--- a/tests/integration/mock_test.ts
+++ b/tests/integration/mock_test.ts
@@ -173,24 +173,24 @@ Rhum.testPlan("mock_test.ts", () => {
       );
       Rhum.asserts.assertEquals(router.calls.handle, 3);
     });
+
+    Rhum.testCase("Sets the default value for getters", () => {
+      class Game {
+  
+      }
+      class PlayersEngine {
+        private game = new Game
+        get Game() {
+          return this.game
+        }
+        set Game(val: Game) {
+          this.game = val
+        }
+      }
+      const mock = Rhum.mock(PlayersEngine).create();
+      Rhum.asserts.assertEquals(mock.Game instanceof Game, true)
+    })
   });
-
-  await t.step("Sets the default value for getters", () => {
-    class Game {
-
-    }
-    class PlayersEngine {
-      private game = new Game
-      get Game() {
-        return this.game
-      }
-      set Game(val: Game) {
-        this.game = val
-      }
-    }
-    const mock = Mock(PlayersEngine).create();
-    assertEquals(mock.Game instanceof Game, true)
-  })
 });
 
 Rhum.run();


### PR DESCRIPTION
closes #145 

problem was, the class was initialised with a default prop, so `mock.Game` should return it. Instead it was returning undefined:

**Before**
```ts
const mock = Mock(PlayersEngine).create()
mock.Game // undefined
mock.Game = "hello"
mock.game // "hello"
```

**After**
```ts
const mock = Mock(PlayersEngine).create()
mock.Game // "default game"
mock.Game = "hello"
mock.game // "hello"
```