### PR TITLE
ci: update release drafter to reflect v2; use drash template

### DIFF
--- a/.github/release_drafter_config.yml
+++ b/.github/release_drafter_config.yml
@@ -42,13 +42,25 @@ template: |
   ```typescript
   // deps.ts
 
-  export { Dummy, Fake, Mock, Stub } from "https://deno.land/x/rhum@v$RESOLVED_VERSION/mod.ts";
+  export {
+    Dummy,
+    Fake,
+    Mock,
+    Spy,
+    Stub
+  } from "https://deno.land/x/rhum@v$RESOLVED_VERSION/mod.ts";
   ```
 
   2. Import the test doubles from your `deps.ts` file.
 
   ```typescript
-  import { Dummy, Fake, Mock, Stub } from "./deps.ts"
+  import {
+    Dummy,
+    Fake,
+    Mock,
+    Spy,
+    Stub
+  } from "./deps.ts"
 
   ... your
   ... code

--- a/.github/release_drafter_config.yml
+++ b/.github/release_drafter_config.yml
@@ -22,22 +22,40 @@ version-resolver:
     labels:
       - 'Type: Patch'
       - 'Type: Chore' # allow our chore PR's to just be patches too
-  default: patch
+  default: 'patch'
 
 # What our release will look like. If no draft has been created, then this will be used, otherwise $CHANGES just gets addedd
 template: |
-  __Compatibility__
+  ## Compatibility
 
-  * Requires Deno v<DENO_VERSION> or higher
-  * Uses Deno std@<STD_VERSION>
+  Requires Deno v<version>
+  Uses Deno Standard Modules <version>
 
-  __Importing__
+  ## Documentation
 
-  * Import this latest release by using the following in your project(s):
-    ```typescript
-    import { Rhum } from "https://deno.land/x/rhum@v$RESOLVED_VERSION/mod.ts";
-    ```
+  * [Full Documentation](https://drash.land/rhum/v2.x/getting-started/introduction)
 
-  __Updates__
+  ## Usage
+
+  1. Create a `deps.ts` file.
+
+  ```typescript
+  // deps.ts
+
+  export { Dummy, Fake, Mock, Stub } from "https://deno.land/x/rhum@v$RESOLVED_VERSION/mod.ts";
+  ```
+
+  2. Import the test doubles from your `deps.ts` file.
+
+  ```typescript
+  import { Dummy, Fake, Mock, Stub } from "./deps.ts"
+
+  ... your
+  ... code
+  ... here
+  ```
+
+  ## Release Summary
 
   $CHANGES
+  

--- a/.github/release_drafter_config.yml
+++ b/.github/release_drafter_config.yml
@@ -29,7 +29,6 @@ template: |
   ## Compatibility
 
   Requires Deno v<version>
-  Uses Deno Standard Modules <version>
 
   ## Documentation
 

--- a/.github/release_drafter_config.yml
+++ b/.github/release_drafter_config.yml
@@ -22,14 +22,14 @@ version-resolver:
     labels:
       - 'Type: Patch'
       - 'Type: Chore' # allow our chore PR's to just be patches too
-  default: 'patch'
+  default: 'Type: Patch'
 
 # What our release will look like. If no draft has been created, then this will be used, otherwise $CHANGES just gets addedd
 template: |
   ## Compatibility
 
   * Requires Deno v<version>
-  * Requires Node v<version>
+  * Requires Node v14, v16, v17, or v18
 
   ## Documentation
 

--- a/.github/release_drafter_config.yml
+++ b/.github/release_drafter_config.yml
@@ -28,7 +28,8 @@ version-resolver:
 template: |
   ## Compatibility
 
-  Requires Deno v<version>
+  * Requires Deno v<version>
+  * Requires Node v<version>
 
   ## Documentation
 


### PR DESCRIPTION
## Summary

- Updates release drafter to use Drash's template.
- Fixes example code to use Rhum v2 test doubles.
