### PR TITLE
ci: pre-check release version when releasing to node ecosystem

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 on:
   release:
     types: [published]
+
+  # In the even this workflow fails, it can be started manually via `workflow_dispatch`
   workflow_dispatch:
 
 jobs:
@@ -16,6 +18,10 @@ jobs:
       # We need deno because the "Build CJS and ESM" step runs `deno run`
       - name: Install Deno
         uses: denoland/setup-deno@v1
+
+      - name: Pre-check release version
+        run: |
+          deno run --allow-read ./console/pre_check_release.ts ${{ github.event.release.tag_name }}
 
       # Setup .npmrc file to publish to npm
       - name: Install Node

--- a/console/pre_check_release.ts
+++ b/console/pre_check_release.ts
@@ -1,0 +1,19 @@
+const versionToPublish = Deno.args[0];
+
+const packageJsonContents = new TextDecoder().decode(
+  Deno.readFileSync("./package.json"),
+);
+
+const packageJson = JSON.parse(packageJsonContents);
+const packageJsonVersion = `v${packageJson.version}`;
+
+console.log("Checking package.json version with GitHub release tag version.\n");
+console.log(`packge.json version:    ${packageJsonVersion}`);
+console.log(`GitHub release version: ${versionToPublish}\n`);
+
+if (packageJsonVersion !== versionToPublish) {
+  console.log("Version mismatch. Stopping Release workflow.");
+  Deno.exit(1);
+} else {
+  console.log("Versions match. Proceeding with Release workflow.");
+}

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   "license": "MIT",
   "scripts": {
     "build": "console/build_esm_lib && yarn build:cjs && yarn build:esm",
-    "build:windows": "bash console/build_esm_lib && yarn build:cjs && yarn build:esm",
     "build:cjs": "tsc --project tsconfig.cjs.json",
+    "build:conversion-workspace": "deno run --allow-read --allow-write ./console/build_esm_lib.ts",
     "build:esm": "tsc --project tsconfig.esm.json",
+    "build:windows": "bash console/build_esm_lib && yarn build:cjs && yarn build:esm",
     "check": "rm -rf node_modules/ && rm yarn.lock && yarn install && yarn build && yarn test",
     "test": "jest"
   },


### PR DESCRIPTION
Adds pre-check in release workflow to make sure `package.json` version matches the version that was released. This will help prevent accidentally releasing a version that does not match what we release in Deno.