### PR TITLE
fix: OriginalObject not assignable to type object

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -216,6 +216,10 @@ export function Stub<OriginalObject, ReturnValue>(
   dataMember?: keyof OriginalObject,
   returnValue?: ReturnValue,
 ): unknown {
+  if (obj === null) {
+    throw new Error(`Cannot create a stub using Stub(null)`)
+  }
+
   if (obj === undefined) {
     return function stubbed() {
       return "stubbed";

--- a/mod.ts
+++ b/mod.ts
@@ -217,7 +217,7 @@ export function Stub<OriginalObject, ReturnValue>(
   returnValue?: ReturnValue,
 ): unknown {
   if (obj === null) {
-    throw new Error(`Cannot create a stub using Stub(null)`)
+    throw new Error(`Cannot create a stub using Stub(null)`);
   }
 
   if (obj === undefined) {

--- a/src/fake/fake_mixin.ts
+++ b/src/fake/fake_mixin.ts
@@ -65,7 +65,9 @@ export function createFake<OriginalConstructor, OriginalObject>(
         methodName,
       );
 
-      if (!((methodName as string) in (this.#original as Record<string, unknown>))) {
+      if (
+        !((methodName as string) in (this.#original as Record<string, unknown>))
+      ) {
         const typeSafeMethodName = String(methodName as string);
 
         throw new FakeError(

--- a/src/fake/fake_mixin.ts
+++ b/src/fake/fake_mixin.ts
@@ -65,7 +65,7 @@ export function createFake<OriginalConstructor, OriginalObject>(
         methodName,
       );
 
-      if (!((methodName as string) in this.#original)) {
+      if (!((methodName as string) in (this.#original as Record<string, unknown>))) {
         const typeSafeMethodName = String(methodName as string);
 
         throw new FakeError(

--- a/src/mock/mock_mixin.ts
+++ b/src/mock/mock_mixin.ts
@@ -182,7 +182,7 @@ export function createMock<OriginalConstructor, OriginalObject>(
         methodName,
       );
 
-      if (!((methodName as string) in this.#original)) {
+      if (!((methodName as string) in (this.#original as Record<string, unknown>))) {
         const typeSafeMethodName = String(methodName);
         throw new MockError(
           `Method "${typeSafeMethodName}" does not exist.`,

--- a/src/mock/mock_mixin.ts
+++ b/src/mock/mock_mixin.ts
@@ -182,7 +182,9 @@ export function createMock<OriginalConstructor, OriginalObject>(
         methodName,
       );
 
-      if (!((methodName as string) in (this.#original as Record<string, unknown>))) {
+      if (
+        !((methodName as string) in (this.#original as Record<string, unknown>))
+      ) {
         const typeSafeMethodName = String(methodName);
         throw new MockError(
           `Method "${typeSafeMethodName}" does not exist.`,

--- a/tests/deno/unit/mod/stub_test.ts
+++ b/tests/deno/unit/mod/stub_test.ts
@@ -45,7 +45,13 @@ Deno.test("Stub()", async (t) => {
 
   await t.step("throws error on Stub(null) calls", () => {
     try {
-      const stub = Stub(null, "prop");
+      // @ts-ignore This test ensures an error is thrown when `null` is being
+      // provided as the object containing the property or method to stub. It is
+      // the first check in the `Stub()` call. Even though `Stub(null)` cannot
+      // happen in TypeScript if type-checking is on, this can still happen in
+      // JS. This is ignored because it is being tested in TypeScript, but this
+      // SHOULD only happen in JavaScript.
+      Stub(null, "prop");
     } catch (error) {
       assertEquals(error.message, "Cannot create a stub using Stub(null)");
     }

--- a/tests/deno/unit/mod/stub_test.ts
+++ b/tests/deno/unit/mod/stub_test.ts
@@ -42,4 +42,12 @@ Deno.test("Stub()", async (t) => {
     const stub = Stub();
     assertEquals(stub(), "stubbed");
   });
+
+  await t.step("throws error on Stub(null) calls", () => {
+    try {
+      const stub = Stub(null, "prop");
+    } catch (error) {
+      assertEquals(error.message, "Cannot create a stub using Stub(null)");
+    }
+  });
 });


### PR DESCRIPTION
- Cherry pick ce19c16e0d2f9254912ebd5c1c33984ea51b2b3d from #172 to fix `main`
- Also fix some checks that didn't happen before or somehow skipped being checked in the tests